### PR TITLE
Fix project title word break on projects overview page

### DIFF
--- a/client/src/components/Projects/Projects.module.scss
+++ b/client/src/components/Projects/Projects.module.scss
@@ -91,11 +91,11 @@
   .openTitle {
     bottom: 0;
     font-size: 24px;
+    hyphens: auto;
     left: 0;
     line-height: 1.1;
     padding: 24px 20px;
     position: absolute;
-    hyphens: auto;
     word-break: break-word;
   }
 

--- a/client/src/components/Projects/Projects.module.scss
+++ b/client/src/components/Projects/Projects.module.scss
@@ -95,6 +95,8 @@
     line-height: 1.1;
     padding: 24px 20px;
     position: absolute;
+    hyphens: auto;
+    word-break: break-word;
   }
 
   .project {


### PR DESCRIPTION
Hey,

on phones or smaller displays in general, if the title of a project is too long for the box, it overflows.

![grafik](https://user-images.githubusercontent.com/7694808/114079086-045d0780-98aa-11eb-934c-81e205b57be2.png)

I've added hyphenation/word-break to the scss file (hyphens if browser/word supports it, and word-break if not).

![grafik](https://user-images.githubusercontent.com/7694808/114079215-2fdff200-98aa-11eb-9068-d7bdf08a3fbb.png)

