### PR TITLE
Fix misspelling of "management".

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Planka is an open source project managment software"
+      content="Planka is an open source project management software"
     />
     <link rel="apple-touch-icon" href="logo192.png" />
     <!--

--- a/client/src/components/Login/Login.jsx
+++ b/client/src/components/Login/Login.jsx
@@ -189,7 +189,7 @@ const Login = React.memo(
               <Header
                 inverted
                 as="h2"
-                content={t('common.projectManagment')}
+                content={t('common.projectManagement')}
                 className={styles.descriptionSubtitle}
               />
             </div>

--- a/client/src/locales/cs/embed.js
+++ b/client/src/locales/cs/embed.js
@@ -8,7 +8,7 @@ export default {
       noInternetConnection: 'Bez připojení k internetu',
       pageNotFound_title: 'Stránka nenalezena',
       password: 'Heslo',
-      projectManagment: 'Správa projektu',
+      projectManagement: 'Správa projektu',
       serverConnectionFailed: 'Připojení k serveru selhalo',
       unknownError: 'Neznámá chyba, zkuste to později',
     },

--- a/client/src/locales/de/embed.js
+++ b/client/src/locales/de/embed.js
@@ -8,7 +8,7 @@ export default {
       noInternetConnection: 'Keine Internetverbindung',
       pageNotFound_title: 'Seite nicht gefunden',
       password: 'Passwort',
-      projectManagment: 'Projekt Management',
+      projectManagement: 'Projekt Management',
       serverConnectionFailed: 'Serververbindung fehlgeschlagen',
       unknownError: 'Unbekannter Fehler, bitte später erneut versuchen',
     },

--- a/client/src/locales/en/embed.js
+++ b/client/src/locales/en/embed.js
@@ -8,7 +8,7 @@ export default {
       noInternetConnection: 'No internet connection',
       pageNotFound_title: 'Page Not Found',
       password: 'Password',
-      projectManagment: 'Project managment',
+      projectManagement: 'Project management',
       serverConnectionFailed: 'Server connection failed',
       unknownError: 'Unknown error, try again later',
     },

--- a/client/src/locales/es/embed.js
+++ b/client/src/locales/es/embed.js
@@ -8,7 +8,7 @@ export default {
       noInternetConnection: 'Sin conexión a internet',
       pageNotFound_title: 'Página no encontrada',
       password: 'Contraseña',
-      projectManagment: 'Gestión de Proyectos',
+      projectManagement: 'Gestión de Proyectos',
       serverConnectionFailed: 'Conexión con el servidor fallida',
       unknownError: 'Error desconocido, intenta más tarde',
     },

--- a/client/src/locales/fr/embed.js
+++ b/client/src/locales/fr/embed.js
@@ -8,7 +8,7 @@ export default {
       noInternetConnection: 'Aucune connection internet',
       pageNotFound_title: 'Page non trouvée',
       password: 'Mot de passe',
-      projectManagment: 'Gestion de projet',
+      projectManagement: 'Gestion de projet',
       serverConnectionFailed: 'Connection au serveur échouée',
       unknownError: 'Erreur inconnue, réessayez plus tard',
     },

--- a/client/src/locales/pl/embed.js
+++ b/client/src/locales/pl/embed.js
@@ -8,7 +8,7 @@ export default {
       noInternetConnection: 'Brak połączenia z internetem',
       pageNotFound_title: 'Nie znaleziono strony',
       password: 'Hasło',
-      projectManagment: 'Zarządzanie projektem',
+      projectManagement: 'Zarządzanie projektem',
       serverConnectionFailed: 'Błąd połączenia z serwerem',
       unknownError: 'Nieznany błąd, spróbuj ponownie później',
     },

--- a/client/src/locales/ru/embed.js
+++ b/client/src/locales/ru/embed.js
@@ -8,7 +8,7 @@ export default {
       noInternetConnection: 'Нет соединения',
       pageNotFound: 'Страница не найдена',
       password: 'Пароль',
-      projectManagment: 'Управление проектами',
+      projectManagement: 'Управление проектами',
       serverConnectionFailed: 'Не могу подключиться к серверу',
       unknownError: 'Что-то пошло не так, попробуйте позже',
     },


### PR DESCRIPTION
In a few source files this word was misspelled. I noticed it right away on the login screen of my self-hosted instance.