### PR TITLE
Make TRUST_PROXY configurable via environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - 3000:1337
     environment:
       - BASE_URL=http://localhost:3000
+      - TRUST_PROXY=false
       - DATABASE_URL=postgresql://postgres@postgres/planka
       - SECRET_KEY=notsecretkey
     depends_on:

--- a/server/config/env/production.js
+++ b/server/config/env/production.js
@@ -273,7 +273,7 @@ module.exports = {
      *
      */
 
-    // trustProxy: true,
+    trustProxy: process.env.TRUST_PROXY,
   },
 
   /**


### PR DESCRIPTION
Hi,

This PR makes the `trustProxy` value in `server/config/env/production.js` configurable using the environment variable `TRUST_PROXY`.

This PR relates to issue #163

Default value in docker-compose.yml is false but if running behind a reverse proxy, it is encouraged to set to true.

Please hold off on merging until I have fully tested.

