### PR TITLE
Migrations: alway apply migrations on start-up

### DIFF
--- a/server/db/init.js
+++ b/server/db/init.js
@@ -6,8 +6,8 @@ const knex = require('knex')(config); // eslint-disable-line import/order
   try {
     const isExists = await knex.schema.hasTable(config.migrations.tableName);
 
+    await knex.migrate.latest();
     if (!isExists) {
-      await knex.migrate.latest();
       await knex.seed.run();
     }
   } catch (error) {


### PR DESCRIPTION
Migrations should never be updated or deleted, all changes to the schema should happen through `knex migrate:make` so whenever a user runs newer version - their DB schema gets updated automatically.