### PR TITLE
Improve Docker cache efficiency and fix signal handling

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-
-node db/init.js \
-  && node app.js --prod $@
+set -e
+node db/init.js
+exec node app.js --prod $@


### PR DESCRIPTION
The current Dockerfile performs an expensive install of all node modules for every source change. That's not necessary as npm install only depends on the `package.json`, `package-lock.json` and `.npmrc` files. This change leads to much better use of Docker's layer cache, keeping all NPM packages in a cached layer as long as only code is changed.

It also fixes an issue where SIGTERMs sent to the container wouldn't get delivered to NodeJS because bash ran as PID 1 and does not forward signals. By exec'ing into node it is now PID 1 inside the container and thus gets the SIGTERM directly.