### PR TITLE
DB Migration: ProjectManager wrong "down"-name

### DIFF
--- a/server/db/migrations/20180721234154_create_project_manager_table.js
+++ b/server/db/migrations/20180721234154_create_project_manager_table.js
@@ -16,4 +16,4 @@ module.exports.up = (knex) =>
     table.index('user_id');
   });
 
-module.exports.down = (knex) => knex.schema.dropTable('project_membership');
+module.exports.down = (knex) => knex.schema.dropTable('project_manager');


### PR DESCRIPTION
Reflect the name change of the table to 'project_manager' also in the down command.