### PR TITLE
Add remark breaks plugin for line breaks.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,6 +34,7 @@
         "redux-logger": "^3.0.6",
         "redux-orm": "^0.16.2",
         "redux-saga": "^1.1.3",
+        "remark-breaks": "^3.0.2",
         "remark-gfm": "^3.0.1",
         "reselect": "^4.1.5",
         "sails.io.js": "^1.2.1",
@@ -18824,6 +18825,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark-breaks": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-3.0.2.tgz",
+      "integrity": "sha512-x96YDJ9X+Ry0/JNZFKfr1hpcAKvGYWfUTszxY9RbxKEqq6uzPPoLCuHdZsLPZZUdAv3nCROyc7FPrQLWr2rxyw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
@@ -36760,6 +36775,16 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
+    "remark-breaks": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-3.0.2.tgz",
+      "integrity": "sha512-x96YDJ9X+Ry0/JNZFKfr1hpcAKvGYWfUTszxY9RbxKEqq6uzPPoLCuHdZsLPZZUdAv3nCROyc7FPrQLWr2rxyw==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0"
+      }
     },
     "remark-gfm": {
       "version": "3.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -91,6 +91,7 @@
     "redux-logger": "^3.0.6",
     "redux-orm": "^0.16.2",
     "redux-saga": "^1.1.3",
+    "remark-breaks": "^3.0.2",
     "remark-gfm": "^3.0.1",
     "reselect": "^4.1.5",
     "sails.io.js": "^1.2.1",

--- a/client/src/lib/custom-ui/components/Markdown/Markdown.jsx
+++ b/client/src/lib/custom-ui/components/Markdown/Markdown.jsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 
 import './Markdown.module.scss'; // FIXME: import as styles?
 
@@ -35,7 +36,7 @@ const Markdown = React.memo(({ linkStopPropagation, ...props }) => {
     <ReactMarkdown
       {...props}
       components={components}
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkBreaks]}
       className="markdown-body"
     />
     /* eslint-enable react/jsx-props-no-spreading */


### PR DESCRIPTION
related: #257

By introducing [remarkjs/remark-breaks](https://github.com/remarkjs/remark-breaks) as a Markdown plugin, users can realize general line breaks in the comment and description fields.