### PR TITLE
feat: Prefill label creation with search term

### DIFF
--- a/client/src/components/LabelsStep/AddStep.jsx
+++ b/client/src/components/LabelsStep/AddStep.jsx
@@ -10,11 +10,11 @@ import Editor from './Editor';
 
 import styles from './AddStep.module.scss';
 
-const AddStep = React.memo(({ onCreate, onBack }) => {
+const AddStep = React.memo(({ onCreate, onBack, initialValue }) => {
   const [t] = useTranslation();
 
   const [data, handleFieldChange] = useForm(() => ({
-    name: '',
+    name: initialValue,
     color: LabelColors[0],
   }));
 
@@ -48,6 +48,7 @@ const AddStep = React.memo(({ onCreate, onBack }) => {
 AddStep.propTypes = {
   onCreate: PropTypes.func.isRequired,
   onBack: PropTypes.func.isRequired,
+  initialValue: PropTypes.func.isRequired,
 };
 
 export default AddStep;

--- a/client/src/components/LabelsStep/LabelsStep.jsx
+++ b/client/src/components/LabelsStep/LabelsStep.jsx
@@ -84,7 +84,7 @@ const LabelsStep = React.memo(
     if (step) {
       switch (step.type) {
         case StepTypes.ADD:
-          return <AddStep onCreate={onCreate} onBack={handleBack} />;
+          return <AddStep onCreate={onCreate} onBack={handleBack} initialValue={search} />;
         case StepTypes.EDIT: {
           const currentItem = items.find((item) => item.id === step.params.id);
 


### PR DESCRIPTION
This PR updates the label creation workflow.

When you search for a label name and no matching label exists with that name, you have the option of creating a new label. However, currently you have to enter the label name again. After this change, the label name field is pre-filled with the last value of the search field.

[Screen recording](https://user-images.githubusercontent.com/9086585/193411488-b013d20a-99b3-41da-963c-bca8dfd9ce2f.webm)
