### PR TITLE
fix: Fix npm install errors on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "client:test": "npm test --prefix client",
     "docker:build": "docker build -t ghcr.io/plankanban/planka:local -f Dockerfile .",
     "docker:build:base": "docker build -t ghcr.io/plankanban/planka:base-local -f Dockerfile.base .",
-    "postinstall": "npm i --prefix server && npm i --prefix client",
+	"postinstall": "(cd server && npm i && cd ../client && npm i)",
     "lint": "npm run server:lint && npm run client:lint",
     "prepare": "husky install",
     "server:console": "npm run console --prefix server",


### PR DESCRIPTION
FIxed npm install errors on Windows
Working on: Windows 10 (10.0.19044), Ubuntu 22.04.1

There seems to be an issue with --prefix on Windows, but only in npm install.
() to start a subshell and don't change dir, but it should also work without it.