### PR TITLE
feat: Added card counts for columns with extra information while filtering

### DIFF
--- a/client/src/components/Board/ListAdd.jsx
+++ b/client/src/components/Board/ListAdd.jsx
@@ -10,6 +10,7 @@ import styles from './ListAdd.module.scss';
 
 const DEFAULT_DATA = {
   name: '',
+  isCollapsed: false,
 };
 
 const ListAdd = React.memo(({ onCreate, onClose }) => {

--- a/client/src/components/BoardActions/BoardActions.jsx
+++ b/client/src/components/BoardActions/BoardActions.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { useTranslation } from 'react-i18next';
+import classNames from 'classnames';
 import Filters from './Filters';
 import Memberships from '../Memberships';
 import BoardMembershipPermissionsSelectStep from '../BoardMembershipPermissionsSelectStep';
@@ -9,6 +11,7 @@ import styles from './BoardActions.module.scss';
 
 const BoardActions = React.memo(
   ({
+    cardCount,
     memberships,
     labels,
     filterUsers,
@@ -28,9 +31,14 @@ const BoardActions = React.memo(
     onLabelMove,
     onLabelDelete,
   }) => {
+    const [t] = useTranslation();
+
     return (
       <div className={styles.wrapper}>
         <div className={styles.actions}>
+          <div className={classNames(styles.cardsCount, styles.action)}>
+            {cardCount} {[cardCount !== 1 ? t('common.cards') : t('common.card')]}
+          </div>
           <div className={styles.action}>
             <Memberships
               items={memberships}
@@ -67,6 +75,7 @@ const BoardActions = React.memo(
 
 BoardActions.propTypes = {
   /* eslint-disable react/forbid-prop-types */
+  cardCount: PropTypes.number.isRequired,
   memberships: PropTypes.array.isRequired,
   labels: PropTypes.array.isRequired,
   filterUsers: PropTypes.array.isRequired,

--- a/client/src/components/BoardActions/BoardActions.module.scss
+++ b/client/src/components/BoardActions/BoardActions.module.scss
@@ -1,4 +1,9 @@
 :global(#app) {
+  .cardsCount {
+    color: #798d99;
+    font-size: 12px;
+  }
+
   .action {
     flex: 0 0 auto;
     margin-right: 20px;

--- a/client/src/components/List/List.jsx
+++ b/client/src/components/List/List.jsx
@@ -117,6 +117,10 @@ const List = React.memo(
                     </Button>
                   </ActionsPopup>
                 )}
+                <div className={styles.cardsCount}>
+                  {cardIds.length}&nbsp;
+                  {cardIds.length !== 1 ? t('common.cards') : t('common.card')}
+                </div>
               </div>
               <div
                 ref={listWrapper}

--- a/client/src/components/List/List.jsx
+++ b/client/src/components/List/List.jsx
@@ -16,7 +16,7 @@ import styles from './List.module.scss';
 
 const List = React.memo(
   // eslint-disable-next-line prettier/prettier
-  ({ id, index, name, isPersisted, isCollapsed, isFiltered, cardIds, cardIdsFull, canEdit, onUpdate, onDelete, onCardCreate }) => {
+  ({ id, index, name, isPersisted, isCollapsed, cardIds, isFiltered, filteredCardIds, canEdit, onUpdate, onDelete, onCardCreate }) => {
     const [t] = useTranslation();
     const [isAddCardOpened, setIsAddCardOpened] = useState(false);
 
@@ -66,7 +66,7 @@ const List = React.memo(
       if (isAddCardOpened) {
         listWrapper.current.scrollTop = listWrapper.current.scrollHeight;
       }
-    }, [cardIds, isAddCardOpened]);
+    }, [filteredCardIds, isAddCardOpened]);
 
     const cardsNode = (
       <Droppable
@@ -78,7 +78,7 @@ const List = React.memo(
           // eslint-disable-next-line react/jsx-props-no-spreading
           <div {...droppableProps} ref={innerRef}>
             <div className={styles.cards}>
-              {cardIds.map((cardId, cardIndex) => (
+              {filteredCardIds.map((cardId, cardIndex) => (
                 <CardContainer key={cardId} id={cardId} index={cardIndex} />
               ))}
               {placeholder}
@@ -99,9 +99,9 @@ const List = React.memo(
       return (
         [
           isFiltered
-            ? `${cardIds.length} ${t('common.of')} ${cardIdsFull.length} `
-            : `${cardIdsFull.length} `,
-        ] + [cardIdsFull.length !== 1 ? t('common.cards') : t('common.card')]
+            ? `${filteredCardIds.length} ${t('common.of')} ${cardIds.length} `
+            : `${cardIds.length} `,
+        ] + [cardIds.length !== 1 ? t('common.cards') : t('common.card')]
       );
     };
 
@@ -210,7 +210,7 @@ const List = React.memo(
                 >
                   <PlusMathIcon className={styles.addCardButtonIcon} />
                   <span className={styles.addCardButtonText}>
-                    {cardIds.length > 0 ? t('action.addAnotherCard') : t('action.addCard')}
+                    {filteredCardIds.length > 0 ? t('action.addAnotherCard') : t('action.addCard')}
                   </span>
                 </button>
               )}
@@ -228,9 +228,9 @@ List.propTypes = {
   name: PropTypes.string.isRequired,
   isCollapsed: PropTypes.bool.isRequired,
   isPersisted: PropTypes.bool.isRequired,
-  isFiltered: PropTypes.bool.isRequired,
   cardIds: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-  cardIdsFull: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  isFiltered: PropTypes.bool.isRequired,
+  filteredCardIds: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   canEdit: PropTypes.bool.isRequired,
   onUpdate: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,

--- a/client/src/components/List/List.jsx
+++ b/client/src/components/List/List.jsx
@@ -133,7 +133,7 @@ const List = React.memo(
                     )}
                     onClick={handleToggleCollapseClick}
                   >
-                    <Icon fitted name="triangle down" size="mid" />
+                    <Icon fitted name="triangle down" />
                   </div>
                   <div className={styles.headerNameCollapsed}>{name}</div>
                   <div className={styles.headerCardsCountCollapsed}>{cardsCountText()}</div>
@@ -167,7 +167,7 @@ const List = React.memo(
                   )}
                   onClick={handleToggleCollapseClick}
                 >
-                  <Icon fitted name="triangle right" size="mid" />
+                  <Icon fitted name="triangle right" />
                 </div>
                 <NameEdit ref={nameEdit} defaultValue={name} onUpdate={handleNameUpdate}>
                   {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,

--- a/client/src/components/List/List.jsx
+++ b/client/src/components/List/List.jsx
@@ -15,7 +15,8 @@ import { ReactComponent as PlusMathIcon } from '../../assets/images/plus-math-ic
 import styles from './List.module.scss';
 
 const List = React.memo(
-  ({ id, index, name, isPersisted, cardIds, canEdit, onUpdate, onDelete, onCardCreate }) => {
+  // eslint-disable-next-line prettier/prettier
+  ({ id, index, name, isPersisted, isFiltered, cardIds, cardIdsFull, canEdit, onUpdate, onDelete, onCardCreate }) => {
     const [t] = useTranslation();
     const [isAddCardOpened, setIsAddCardOpened] = useState(false);
 
@@ -86,6 +87,16 @@ const List = React.memo(
       </Droppable>
     );
 
+    const cardsCountText = () => {
+      return (
+        [
+          isFiltered
+            ? `${cardIds.length} ${t('common.of')} ${cardIdsFull.length} `
+            : `${cardIdsFull.length} `,
+        ] + [cardIdsFull.length !== 1 ? t('common.cards') : t('common.card')]
+      );
+    };
+
     return (
       <Draggable draggableId={`list:${id}`} index={index} isDragDisabled={!isPersisted || !canEdit}>
         {({ innerRef, draggableProps, dragHandleProps }) => (
@@ -117,10 +128,7 @@ const List = React.memo(
                     </Button>
                   </ActionsPopup>
                 )}
-                <div className={styles.cardsCount}>
-                  {cardIds.length}&nbsp;
-                  {cardIds.length !== 1 ? t('common.cards') : t('common.card')}
-                </div>
+                <div className={styles.cardsCount}>{cardsCountText()}</div>
               </div>
               <div
                 ref={listWrapper}
@@ -157,7 +165,9 @@ List.propTypes = {
   index: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
   isPersisted: PropTypes.bool.isRequired,
+  isFiltered: PropTypes.bool.isRequired,
   cardIds: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  cardIdsFull: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   canEdit: PropTypes.bool.isRequired,
   onUpdate: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,

--- a/client/src/components/List/List.module.scss
+++ b/client/src/components/List/List.module.scss
@@ -39,6 +39,11 @@
     min-height: 1px;
   }
 
+  .cardsCount {
+    color: #798d99;
+    font-size: 12px;
+  }
+
   .cardsInnerWrapper {
     max-height: calc(100vh - 268px);
     overflow-x: hidden;

--- a/client/src/components/List/List.module.scss
+++ b/client/src/components/List/List.module.scss
@@ -39,11 +39,6 @@
     min-height: 1px;
   }
 
-  .cardsCount {
-    color: #798d99;
-    font-size: 12px;
-  }
-
   .cardsInnerWrapper {
     max-height: calc(100vh - 268px);
     overflow-x: hidden;
@@ -80,8 +75,17 @@
 
   .header {
     outline: none;
-    padding: 6px 36px 4px 8px;
+    padding: 4px 36px 4px 10px;
     position: relative;
+
+    &:hover .target {
+      opacity: 1;
+    }
+  }
+
+  .headerCollapsed {
+    outline: none;
+    height: calc(100vh - 182px);
 
     &:hover .target {
       opacity: 1;
@@ -119,13 +123,56 @@
     outline: none;
     overflow: hidden;
     overflow-wrap: break-word;
-    padding: 4px 8px;
     word-break: break-word;
+  }
+
+  .headerNameCollapsed {
+    color: #17394d;
+    font-weight: bold;
+    outline: none;
+    overflow: hidden;
+    writing-mode: vertical-rl;
+    padding: 0px 5px 10px 5px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-height: 85%;
+  }
+
+  .headerCollapseButton {
+    width: 10px;
+    height: 30px;
+    padding: 2px 0px 0px 2px;
+    position: absolute;
+    left: 2px;
+    top: 2px;
+  }
+
+  .headerCollapseButtonCollapsed {
+    height: 30px;
+    text-align: center;
+  }
+
+  .headerCardsCount {
+    color: #798d99;
+    font-size: 12px;
+  }
+
+  .headerCardsCountCollapsed {
+    color: #798d99;
+    font-size: 12px;
+    max-height: 10%;
+    writing-mode: vertical-rl;
+    padding: 0px 5px 10px 5px;
   }
 
   .innerWrapper {
     margin-right: 8px;
     width: 272px;
+  }
+
+  .innerWrapperCollapsed {
+    margin-right: 8px;
+    width: 30px;
   }
 
   .outerWrapper {

--- a/client/src/components/List/List.module.scss
+++ b/client/src/components/List/List.module.scss
@@ -119,11 +119,14 @@
     color: #17394d;
     font-weight: bold;
     line-height: 20px;
-    max-height: 256px;
+    max-height: 82px;
     outline: none;
     overflow: hidden;
     overflow-wrap: break-word;
     word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
   }
 
   .headerNameCollapsed {

--- a/client/src/containers/BoardActionsContainer.js
+++ b/client/src/containers/BoardActionsContainer.js
@@ -7,6 +7,11 @@ import { BoardMembershipRoles } from '../constants/Enums';
 import BoardActions from '../components/BoardActions';
 
 const mapStateToProps = (state) => {
+  const listIds = selectors.selectListIdsForCurrentBoard(state);
+  const listCardsCount = listIds.map(
+    (list) => selectors.selectCardIdsByListId(state, list).cardIdsFull.length,
+  );
+  const cardCount = listCardsCount.reduce((sum, count) => sum + count, 0);
   const allUsers = selectors.selectUsers(state);
   const isCurrentUserManager = selectors.selectIsCurrentUserManagerForCurrentProject(state);
   const memberships = selectors.selectMembershipsForCurrentBoard(state);
@@ -19,6 +24,7 @@ const mapStateToProps = (state) => {
     !!currentUserMembership && currentUserMembership.role === BoardMembershipRoles.EDITOR;
 
   return {
+    cardCount,
     memberships,
     labels,
     filterUsers,

--- a/client/src/containers/BoardActionsContainer.js
+++ b/client/src/containers/BoardActionsContainer.js
@@ -8,9 +8,7 @@ import BoardActions from '../components/BoardActions';
 
 const mapStateToProps = (state) => {
   const listIds = selectors.selectListIdsForCurrentBoard(state);
-  const listCardsCount = listIds.map(
-    (list) => selectors.selectCardIdsByListId(state, list).cardIdsFull.length,
-  );
+  const listCardsCount = listIds.map((list) => selectors.selectCardIdsByListId(state, list).length);
   const cardCount = listCardsCount.reduce((sum, count) => sum + count, 0);
   const allUsers = selectors.selectUsers(state);
   const isCurrentUserManager = selectors.selectIsCurrentUserManagerForCurrentProject(state);

--- a/client/src/containers/ListContainer.js
+++ b/client/src/containers/ListContainer.js
@@ -12,7 +12,7 @@ const makeMapStateToProps = () => {
 
   return (state, { id, index }) => {
     const { name, isPersisted } = selectListById(state, id);
-    const cardIds = selectCardIdsByListId(state, id);
+    const [cardIds, cardIdsFull, isFiltered] = selectCardIdsByListId(state, id);
     const currentUserMembership = selectors.selectCurrentUserMembershipForCurrentBoard(state);
 
     const isCurrentUserEditor =
@@ -23,7 +23,9 @@ const makeMapStateToProps = () => {
       index,
       name,
       isPersisted,
+      isFiltered,
       cardIds,
+      cardIdsFull,
       canEdit: isCurrentUserEditor,
     };
   };

--- a/client/src/containers/ListContainer.js
+++ b/client/src/containers/ListContainer.js
@@ -11,7 +11,7 @@ const makeMapStateToProps = () => {
   const selectCardIdsByListId = selectors.makeSelectCardIdsByListId();
 
   return (state, { id, index }) => {
-    const { name, isPersisted } = selectListById(state, id);
+    const { name, isPersisted, isCollapsed } = selectListById(state, id);
     const { cardIds, cardIdsFull, isFiltered } = selectCardIdsByListId(state, id);
     const currentUserMembership = selectors.selectCurrentUserMembershipForCurrentBoard(state);
 
@@ -22,6 +22,7 @@ const makeMapStateToProps = () => {
       id,
       index,
       name,
+      isCollapsed,
       isPersisted,
       isFiltered,
       cardIds,

--- a/client/src/containers/ListContainer.js
+++ b/client/src/containers/ListContainer.js
@@ -9,10 +9,14 @@ import List from '../components/List';
 const makeMapStateToProps = () => {
   const selectListById = selectors.makeSelectListById();
   const selectCardIdsByListId = selectors.makeSelectCardIdsByListId();
+  const selectIsFilteredByListId = selectors.makeSelectIsFilteredByListId();
+  const selectFilteredCardIdsByListId = selectors.makeSelectFilteredCardIdsByListId();
 
   return (state, { id, index }) => {
     const { name, isPersisted, isCollapsed } = selectListById(state, id);
-    const { cardIds, cardIdsFull, isFiltered } = selectCardIdsByListId(state, id);
+    const cardIds = selectCardIdsByListId(state, id);
+    const isFiltered = selectIsFilteredByListId(state, id);
+    const filteredCardIds = selectFilteredCardIdsByListId(state, id);
     const currentUserMembership = selectors.selectCurrentUserMembershipForCurrentBoard(state);
 
     const isCurrentUserEditor =
@@ -24,9 +28,9 @@ const makeMapStateToProps = () => {
       name,
       isCollapsed,
       isPersisted,
-      isFiltered,
       cardIds,
-      cardIdsFull,
+      isFiltered,
+      filteredCardIds,
       canEdit: isCurrentUserEditor,
     };
   };

--- a/client/src/containers/ListContainer.js
+++ b/client/src/containers/ListContainer.js
@@ -12,7 +12,7 @@ const makeMapStateToProps = () => {
 
   return (state, { id, index }) => {
     const { name, isPersisted } = selectListById(state, id);
-    const [cardIds, cardIdsFull, isFiltered] = selectCardIdsByListId(state, id);
+    const { cardIds, cardIdsFull, isFiltered } = selectCardIdsByListId(state, id);
     const currentUserMembership = selectors.selectCurrentUserMembershipForCurrentBoard(state);
 
     const isCurrentUserEditor =

--- a/client/src/locales/en/core.js
+++ b/client/src/locales/en/core.js
@@ -158,6 +158,8 @@ export default {
       version: 'Version',
       viewer: 'Viewer',
       writeComment: 'Write a comment...',
+      card: 'card',
+      cards: 'cards',
     },
 
     action: {

--- a/client/src/locales/en/core.js
+++ b/client/src/locales/en/core.js
@@ -160,6 +160,7 @@ export default {
       writeComment: 'Write a comment...',
       card: 'card',
       cards: 'cards',
+      of: 'of',
     },
 
     action: {

--- a/client/src/models/List.js
+++ b/client/src/models/List.js
@@ -86,14 +86,15 @@ export default class extends BaseModel {
 
   getFilteredOrderedCardsModelArray() {
     let cardModels = this.getOrderedCardsQuerySet().toModelArray();
+    const cardModelsFull = cardModels;
 
     const filterUserIds = this.board.filterUsers.toRefArray().map((user) => user.id);
     const filterLabelIds = this.board.filterLabels.toRefArray().map((label) => label.id);
-
+    let isFiltered = false;
     if (filterUserIds.length > 0) {
       cardModels = cardModels.filter((cardModel) => {
         const users = cardModel.users.toRefArray();
-
+        isFiltered = true;
         return users.some((user) => filterUserIds.includes(user.id));
       });
     }
@@ -101,12 +102,12 @@ export default class extends BaseModel {
     if (filterLabelIds.length > 0) {
       cardModels = cardModels.filter((cardModel) => {
         const labels = cardModel.labels.toRefArray();
-
+        isFiltered = true;
         return labels.some((label) => filterLabelIds.includes(label.id));
       });
     }
 
-    return cardModels;
+    return [cardModels, cardModelsFull, isFiltered];
   }
 
   deleteRelated() {

--- a/client/src/models/List.js
+++ b/client/src/models/List.js
@@ -10,6 +10,7 @@ export default class extends BaseModel {
     id: attr(),
     position: attr(),
     name: attr(),
+    isCollapsed: attr(),
     boardId: fk({
       to: 'Board',
       as: 'board',

--- a/client/src/models/List.js
+++ b/client/src/models/List.js
@@ -91,6 +91,7 @@ export default class extends BaseModel {
     const filterUserIds = this.board.filterUsers.toRefArray().map((user) => user.id);
     const filterLabelIds = this.board.filterLabels.toRefArray().map((label) => label.id);
     let isFiltered = false;
+
     if (filterUserIds.length > 0) {
       cardModels = cardModels.filter((cardModel) => {
         const users = cardModel.users.toRefArray();
@@ -107,7 +108,7 @@ export default class extends BaseModel {
       });
     }
 
-    return [cardModels, cardModelsFull, isFiltered];
+    return { cardModels, cardModelsFull, isFiltered };
   }
 
   deleteRelated() {

--- a/client/src/models/List.js
+++ b/client/src/models/List.js
@@ -85,18 +85,25 @@ export default class extends BaseModel {
     return this.cards.orderBy('position');
   }
 
+  getOrderedCardsModelArray() {
+    return this.getOrderedCardsQuerySet().toModelArray();
+  }
+
+  getIsFiltered() {
+    const filterUserIds = this.board.filterUsers.toRefArray().map((user) => user.id);
+    const filterLabelIds = this.board.filterLabels.toRefArray().map((label) => label.id);
+    return filterUserIds.length > 0 || filterLabelIds.length > 0;
+  }
+
   getFilteredOrderedCardsModelArray() {
     let cardModels = this.getOrderedCardsQuerySet().toModelArray();
-    const cardModelsFull = cardModels;
 
     const filterUserIds = this.board.filterUsers.toRefArray().map((user) => user.id);
     const filterLabelIds = this.board.filterLabels.toRefArray().map((label) => label.id);
-    let isFiltered = false;
 
     if (filterUserIds.length > 0) {
       cardModels = cardModels.filter((cardModel) => {
         const users = cardModel.users.toRefArray();
-        isFiltered = true;
         return users.some((user) => filterUserIds.includes(user.id));
       });
     }
@@ -104,12 +111,11 @@ export default class extends BaseModel {
     if (filterLabelIds.length > 0) {
       cardModels = cardModels.filter((cardModel) => {
         const labels = cardModel.labels.toRefArray();
-        isFiltered = true;
         return labels.some((label) => filterLabelIds.includes(label.id));
       });
     }
 
-    return { cardModels, cardModelsFull, isFiltered };
+    return cardModels;
   }
 
   deleteRelated() {

--- a/client/src/selectors/core.js
+++ b/client/src/selectors/core.js
@@ -94,7 +94,7 @@ export const selectNextCardPosition = createSelector(
     }
 
     // eslint-disable-next-line prettier/prettier
-    return nextPosition(listModel.getFilteredOrderedCardsModelArray().cardModels, index, excludedId);
+    return nextPosition(listModel.getFilteredOrderedCardsModelArray(), index, excludedId);
   },
 );
 

--- a/client/src/selectors/core.js
+++ b/client/src/selectors/core.js
@@ -93,7 +93,8 @@ export const selectNextCardPosition = createSelector(
       return listModel;
     }
 
-    return nextPosition(listModel.getFilteredOrderedCardsModelArray(), index, excludedId);
+    // eslint-disable-next-line prettier/prettier
+    return nextPosition(listModel.getFilteredOrderedCardsModelArray().cardModels, index, excludedId);
   },
 );
 

--- a/client/src/selectors/lists.js
+++ b/client/src/selectors/lists.js
@@ -33,12 +33,13 @@ export const makeSelectCardIdsByListId = () =>
       if (!listModel) {
         return listModel;
       }
+
       const cardsModelArray = listModel.getFilteredOrderedCardsModelArray();
-      return [
-        cardsModelArray[0].map((cardModel) => cardModel.id),
-        cardsModelArray[1].map((cardModel) => cardModel.id),
-        cardsModelArray[2],
-      ];
+      return {
+        cardIds: cardsModelArray.cardModels.map((cardModel) => cardModel.id),
+        cardIdsFull: cardsModelArray.cardModelsFull.map((cardModel) => cardModel.id),
+        isFiltered: cardsModelArray.isFiltered,
+      };
     },
   );
 

--- a/client/src/selectors/lists.js
+++ b/client/src/selectors/lists.js
@@ -34,20 +34,53 @@ export const makeSelectCardIdsByListId = () =>
         return listModel;
       }
 
-      const cardsModelArray = listModel.getFilteredOrderedCardsModelArray();
-      return {
-        cardIds: cardsModelArray.cardModels.map((cardModel) => cardModel.id),
-        cardIdsFull: cardsModelArray.cardModelsFull.map((cardModel) => cardModel.id),
-        isFiltered: cardsModelArray.isFiltered,
-      };
+      return listModel.getOrderedCardsModelArray().map((cardModel) => cardModel.id);
     },
   );
 
 export const selectCardIdsByListId = makeSelectCardIdsByListId();
+
+export const makeSelectIsFilteredByListId = () =>
+  createSelector(
+    orm,
+    (_, id) => id,
+    ({ List }, id) => {
+      const listModel = List.withId(id);
+
+      if (!listModel) {
+        return listModel;
+      }
+
+      return listModel.getIsFiltered();
+    },
+  );
+
+export const selectIsFilteredByListId = makeSelectIsFilteredByListId();
+
+export const makeSelectFilteredCardIdsByListId = () =>
+  createSelector(
+    orm,
+    (_, id) => id,
+    ({ List }, id) => {
+      const listModel = List.withId(id);
+
+      if (!listModel) {
+        return listModel;
+      }
+
+      return listModel.getFilteredOrderedCardsModelArray().map((cardModel) => cardModel.id);
+    },
+  );
+
+export const selectFilteredCardIdsByListId = makeSelectFilteredCardIdsByListId();
 
 export default {
   makeSelectListById,
   selectListById,
   makeSelectCardIdsByListId,
   selectCardIdsByListId,
+  makeSelectIsFilteredByListId,
+  selectIsFilteredByListId,
+  makeSelectFilteredCardIdsByListId,
+  selectFilteredCardIdsByListId,
 };

--- a/client/src/selectors/lists.js
+++ b/client/src/selectors/lists.js
@@ -33,8 +33,12 @@ export const makeSelectCardIdsByListId = () =>
       if (!listModel) {
         return listModel;
       }
-
-      return listModel.getFilteredOrderedCardsModelArray().map((cardModel) => cardModel.id);
+      const cardsModelArray = listModel.getFilteredOrderedCardsModelArray();
+      return [
+        cardsModelArray[0].map((cardModel) => cardModel.id),
+        cardsModelArray[1].map((cardModel) => cardModel.id),
+        cardsModelArray[2],
+      ];
     },
   );
 

--- a/server/api/controllers/lists/create.js
+++ b/server/api/controllers/lists/create.js
@@ -22,6 +22,10 @@ module.exports = {
       type: 'string',
       required: true,
     },
+    isCollapsed: {
+      type: 'boolean',
+      required: true,
+    },
   },
 
   exits: {
@@ -53,7 +57,7 @@ module.exports = {
       throw Errors.NOT_ENOUGH_RIGHTS;
     }
 
-    const values = _.pick(inputs, ['position', 'name']);
+    const values = _.pick(inputs, ['position', 'name', 'isCollapsed']);
 
     const list = await sails.helpers.lists.createOne.with({
       values: {

--- a/server/api/controllers/lists/update.js
+++ b/server/api/controllers/lists/update.js
@@ -21,6 +21,9 @@ module.exports = {
       type: 'string',
       isNotEmptyString: true,
     },
+    isCollapsed: {
+      type: 'boolean',
+    },
   },
 
   exits: {
@@ -52,7 +55,7 @@ module.exports = {
       throw Errors.NOT_ENOUGH_RIGHTS;
     }
 
-    const values = _.pick(inputs, ['position', 'name']);
+    const values = _.pick(inputs, ['position', 'name', 'isCollapsed']);
 
     list = await sails.helpers.lists.updateOne.with({
       values,

--- a/server/api/models/List.js
+++ b/server/api/models/List.js
@@ -19,6 +19,11 @@ module.exports = {
       type: 'string',
       required: true,
     },
+    isCollapsed: {
+      type: 'boolean',
+      required: true,
+      columnName: 'is_collapsed',
+    },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/server/db/migrations/20230112022500_add_list_isCollapsed.js
+++ b/server/db/migrations/20230112022500_add_list_isCollapsed.js
@@ -1,0 +1,9 @@
+module.exports.up = (knex) =>
+  knex.schema.alterTable('list', (table) => {
+    table.boolean('is_collapsed').notNullable().defaultTo(false);
+  });
+
+module.exports.down = (knex) =>
+  knex.schema.alterTable('list', (table) => {
+    table.dropColumn('is_collapsed');
+  });


### PR DESCRIPTION
Please don't "fix" the "<no_cards> cards" alignment, after adding column collapsing feature it will look good :D
I'll try to implement this feature soon, together with board card counts, project card counts and improved version of dashboard to include some stats about projects.

Here is an example of how it works:
![image](https://user-images.githubusercontent.com/13639766/211877593-f3b3b79b-efba-4c7e-93e6-577969e23e6c.png)
and after filtering:
![image](https://user-images.githubusercontent.com/13639766/211877678-9786acb0-aa18-43cf-b70b-aba2ed60ad50.png)
