### PR TITLE
allow postgres connections, that require ssl mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - SECRET_KEY=notsecretkey
       # related: https://github.com/knex/knex/issues/2354
       # As knex does not pass query parameters from the connection string we
-      # have to use environment variables in order to pass the desirec values, e.g.
+      # have to use environment variables in order to pass the desired values, e.g.
       # note: this is optional
       # PGSSLMODE=require
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       - TRUST_PROXY=0
       - DATABASE_URL=postgresql://postgres@postgres/planka
       - SECRET_KEY=notsecretkey
+      # related: https://github.com/knex/knex/issues/2354
+      # As knex does not pass query parameters from the connection string we
+      # have to use environment variables in order to pass the desirec values, e.g.
+      # note: this is optional
+      # PGSSLMODE=require
     depends_on:
       - postgres
 

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -11,7 +11,7 @@ SECRET_KEY=notsecretkey
 
 # related: https://github.com/knex/knex/issues/2354
 # As knex does not pass query parameters from the connection string we
-# have to use environment variables in order to pass the desirec values, e.g.
+# have to use environment variables in order to pass the desired values, e.g.
 # PGSSLMODE=<value>
 
 ## Do not edit this

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -9,6 +9,11 @@ SECRET_KEY=notsecretkey
 # TRUST_PROXY=0
 # TOKEN_EXPIRES_IN=365 # In days
 
+# related: https://github.com/knex/knex/issues/2354
+# As knex does not pass query parameters from the connection string we
+# have to use environment variables in order to pass the desirec values, e.g.
+# PGSSLMODE=<value>
+
 ## Do not edit this
 
 TZ=UTC

--- a/server/db/knexfile.js
+++ b/server/db/knexfile.js
@@ -8,7 +8,12 @@ dotenv.config({
 
 module.exports = {
   client: 'pg',
-  connection: process.env.DATABASE_URL,
+  connection: {
+    connectionString: process.env.DATABASE_URL,
+    ssl: {
+      rejectUnauthorized: false,
+    },
+  },
   migrations: {
     tableName: 'migration',
     directory: path.join(__dirname, 'migrations'),


### PR DESCRIPTION
At the moment knex.js does not pass down connection query parameters to build the connection.
Related: https://github.com/knex/knex/issues/2354

This can be bypassed by setting the corresponding environment variable `PGSSLMODE`.

This PR provides the corresponding documentation. I couldn't find the source code for the official website, so I put this into two places:

- server/.env.sample
- docker-compose.yml

So far there is a ticket open to allow connections to Postgres databases, that offer a self-signed certificate: https://github.com/plankanban/planka/issues/261

This PR will make a change on how the connection string is build, that should be backwards compatible and allows the usage of self-signed certificates.