### PR TITLE
Fix: Keep comment edits when textarea loses focus

### DIFF
--- a/client/src/components/CardModal/Activities/CommentEdit.jsx
+++ b/client/src/components/CardModal/Activities/CommentEdit.jsx
@@ -65,10 +65,7 @@ const CommentEdit = React.forwardRef(({ children, defaultData, onUpdate }, ref) 
     [submit],
   );
 
-  const [handleFieldBlur, handleControlMouseOver, handleControlMouseOut] = useClosableForm(
-    close,
-    isOpened,
-  );
+  const [, handleControlMouseOver, handleControlMouseOut] = useClosableForm(close, isOpened);
 
   const handleSubmit = useCallback(() => {
     submit();
@@ -96,7 +93,6 @@ const CommentEdit = React.forwardRef(({ children, defaultData, onUpdate }, ref) 
         className={styles.field}
         onKeyDown={handleFieldKeyDown}
         onChange={handleFieldChange}
-        onBlur={handleFieldBlur}
       />
       <div className={styles.controls}>
         {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}

--- a/client/src/components/CardModal/Activities/CommentEdit.jsx
+++ b/client/src/components/CardModal/Activities/CommentEdit.jsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import TextareaAutosize from 'react-textarea-autosize';
 import { Button, Form, TextArea } from 'semantic-ui-react';
 
-import { useClosableForm, useForm } from '../../../hooks';
+import { useForm } from '../../../hooks';
 
 import styles from './CommentEdit.module.scss';
 
@@ -35,12 +35,7 @@ const CommentEdit = React.forwardRef(({ children, defaultData, onUpdate }, ref) 
       text: data.text.trim(),
     };
 
-    if (!cleanData.text) {
-      textField.current.ref.current.select();
-      return;
-    }
-
-    if (!dequal(cleanData, defaultData)) {
+    if (cleanData.text && !dequal(cleanData, defaultData)) {
       onUpdate(cleanData);
     }
 
@@ -65,7 +60,9 @@ const CommentEdit = React.forwardRef(({ children, defaultData, onUpdate }, ref) 
     [submit],
   );
 
-  const [, handleControlMouseOver, handleControlMouseOut] = useClosableForm(close, isOpened);
+  const handleFieldBlur = useCallback(() => {
+    submit();
+  }, [submit]);
 
   const handleSubmit = useCallback(() => {
     submit();
@@ -93,16 +90,11 @@ const CommentEdit = React.forwardRef(({ children, defaultData, onUpdate }, ref) 
         className={styles.field}
         onKeyDown={handleFieldKeyDown}
         onChange={handleFieldChange}
-        onBlur={() => submit()}
+        onBlur={handleFieldBlur}
       />
       <div className={styles.controls}>
         {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}
-        <Button
-          positive
-          content={t('action.save')}
-          onMouseOver={handleControlMouseOver}
-          onMouseOut={handleControlMouseOut}
-        />
+        <Button positive content={t('action.save')} />
       </div>
     </Form>
   );

--- a/client/src/components/CardModal/Activities/CommentEdit.jsx
+++ b/client/src/components/CardModal/Activities/CommentEdit.jsx
@@ -93,6 +93,7 @@ const CommentEdit = React.forwardRef(({ children, defaultData, onUpdate }, ref) 
         className={styles.field}
         onKeyDown={handleFieldKeyDown}
         onChange={handleFieldChange}
+        onBlur={() => submit()}
       />
       <div className={styles.controls}>
         {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}


### PR DESCRIPTION
Fixes: #441 

This PR is a proposed fix for the linked issue by not reverting the text-state onBlur callbacks.  This achieves parity with the card Add/Edit description functionality where the "Save" button remains visible with the same focus/blur actions.