### PR TITLE
Feat: add edit icon to project tab component

### DIFF
--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -63,12 +63,14 @@ const Header = React.memo(
                 )}
               >
                 {project.name}
-                <Button
-                  className={classNames(styles.actionsButton, styles.target)}
-                  onClick={handleProjectSettingsClick}
-                >
-                  <Icon fitted name="pencil" size="small" />
-                </Button>
+                {canEditProject && (
+                  <Button
+                    className={classNames(styles.actionsButton, styles.target)}
+                    onClick={handleProjectSettingsClick}
+                  >
+                    <Icon fitted name="pencil" size="small" />
+                  </Button>
+                )}
               </Menu.Item>
             </Menu.Menu>
           )}

--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -59,7 +59,7 @@ const Header = React.memo(
                 {project.name}
                 {canEditProject && (
                   <Button
-                    className={classNames(styles.actionsButton, styles.target)}
+                    className={classNames(styles.editButton, styles.target)}
                     onClick={handleProjectSettingsClick}
                   >
                     <Icon fitted name="pencil" size="small" />

--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
-import { Icon, Menu } from 'semantic-ui-react';
+import { Button, Icon, Menu } from 'semantic-ui-react';
 import { usePopup } from '../../lib/popup';
 
 import Paths from '../../constants/Paths';
@@ -61,9 +61,14 @@ const Header = React.memo(
                   canEditProject && styles.itemHoverable,
                   styles.title,
                 )}
-                onClick={handleProjectSettingsClick}
               >
                 {project.name}
+                <Button
+                  className={classNames(styles.actionsButton, styles.target)}
+                  onClick={handleProjectSettingsClick}
+                >
+                  <Icon fitted name="pencil" size="small" />
+                </Button>
               </Menu.Item>
             </Menu.Menu>
           )}

--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -55,13 +55,7 @@ const Header = React.memo(
               >
                 <Icon fitted name="arrow left" />
               </Menu.Item>
-              <Menu.Item
-                className={classNames(
-                  styles.item,
-                  canEditProject && styles.itemHoverable,
-                  styles.title,
-                )}
-              >
+              <Menu.Item className={classNames(styles.item, styles.title)}>
                 {project.name}
                 {canEditProject && (
                   <Button

--- a/client/src/components/Header/Header.module.scss
+++ b/client/src/components/Header/Header.module.scss
@@ -1,4 +1,20 @@
 :global(#app) {
+  .editButton {
+    background: transparent;
+    box-shadow: none;
+    color: #fff;
+    font-size: 15px;
+    line-height: 34px;
+    margin-left: 8px;
+    opacity: 0;
+    padding: 0;
+    width: 34px;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+  }
+
   .item {
     cursor: auto;
     user-select: auto;
@@ -74,27 +90,5 @@
     background: rgba(0, 0, 0, 0.24);
     display: flex;
     flex: 0 0 auto;
-  }
-
-  .actionsButton {
-    background: none;
-    box-shadow: none;
-    border-radius: 3px;
-    box-sizing: content-box;
-    color: #fff;
-    display: inline-block;
-    text-align: center;
-    margin: 0;
-    min-height: auto;
-    opacity: 0;
-    outline: none;
-    padding: 4px;
-    transition: background 85ms ease;
-    width: 20px;
-    margin-left: 12px;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.08);
-    }
   }
 }

--- a/client/src/components/Header/Header.module.scss
+++ b/client/src/components/Header/Header.module.scss
@@ -11,6 +11,10 @@
     &:hover {
       background: transparent;
       color: rgba(255, 255, 255, 0.9);
+
+      .target {
+        opacity: 1;
+      }
     }
   }
 
@@ -70,5 +74,27 @@
     background: rgba(0, 0, 0, 0.24);
     display: flex;
     flex: 0 0 auto;
+  }
+
+  .actionsButton {
+    background: none;
+    box-shadow: none;
+    border-radius: 3px;
+    box-sizing: content-box;
+    color: #fff;
+    display: inline-block;
+    text-align: center;
+    margin: 0;
+    min-height: auto;
+    opacity: 0;
+    outline: none;
+    padding: 4px;
+    transition: background 85ms ease;
+    width: 20px;
+    margin-left: 12px;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
   }
 }


### PR DESCRIPTION
Closes #450 

Adds the "edit" icon to the project header tab to be a more intuitive target for opening the project-edit-modal.