### PR TITLE
fix(#496): Helmchart - Decoupled BASE_URL from Ingress Host

### DIFF
--- a/charts/planka/Chart.yaml
+++ b/charts/planka/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -64,7 +64,9 @@ spec:
                   name: planka-postgresql-svcbind-custom-user
                   key: uri
             - name: BASE_URL
-              {{- if .Values.ingress.enabled }}
+              {{- if .Values.baseUrl }}
+              value: {{ .Values.baseUrl }}
+              {{- else if .Values.ingress.enabled }}
               value: {{ printf "https://%s" (first .Values.ingress.hosts).host }}
               {{- else }}
               value: http://localhost:3000

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -17,6 +17,10 @@ fullnameOverride: ""
 # Generate a secret using openssl rand -base64 45
 secretkey: ""
 
+# Base url for Planka. Will override `ingress.hosts[0].host`
+# Defaults to `http://localhost:3000` if ingress is disabled.
+baseUrl: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -50,6 +54,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
+      # Used to set planka BASE_URL if no `baseurl` is provided.
     - host: planka.local
       paths:
         - path: /


### PR DESCRIPTION
Fixes #496 

Sets an overall baseUrl value to remove the need for an ingress to set a custom host.

Tested with baseUrl set and unset and behaving as desired. I don't have then environment to triple-check if the ingress method still works but it should. 
