### PR TITLE
Fixed broken build under Windows.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,12 @@
             "**/*.test.js"
           ]
         }
+      ],
+      "prettier/prettier": [
+        "error",
+        {
+          "endOfLine": "auto"
+        }
       ]
     }
   },


### PR DESCRIPTION
`npm run build` failed inside the client folder under Windows. A lot of errors reported, in the form of:

> [eslint]
> src\actions\activities.js
>   Line 1:52:   Delete \`␍\` prettier/prettier

And it went on and on, for different files.

Fixed as suggested in this SO reply:

https://stackoverflow.com/a/53769213