### PR TITLE
feat: Add OIDC_IGNORE_ROLES to disable updating isAdmin on SSO login

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -45,6 +45,7 @@ services:
       # - OIDC_SCOPES=openid email profile
       # - OIDC_ADMIN_ROLES=admin
       # - OIDC_ROLES_ATTRIBUTE=groups
+      # - OIDC_IGNORE_ROLES=true
     depends_on:
       - postgres
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       # - OIDC_SCOPES=openid email profile
       # - OIDC_ADMIN_ROLES=admin
       # - OIDC_ROLES_ATTRIBUTE=groups
+      # - OIDC_IGNORE_ROLES=true
     depends_on:
       - postgres
 

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -28,6 +28,7 @@ SECRET_KEY=notsecretkey
 # OIDC_SCOPES=openid email profile
 # OIDC_ADMIN_ROLES=admin
 # OIDC_ROLES_ATTRIBUTE=groups
+# OIDC_IGNORE_ROLES=true
 
 ## Do not edit this
 

--- a/server/api/helpers/users/get-or-create-one-using-oidc.js
+++ b/server/api/helpers/users/get-or-create-one-using-oidc.js
@@ -92,6 +92,11 @@ module.exports = {
 
     const updateFieldKeys = ['email', 'isAdmin', 'isSso', 'name', 'username'];
 
+    if (sails.config.custom.oidcIgnoreRoles) {
+      // Remove isAdmin from updateFieldKeys
+      updateFieldKeys.splice(updateFieldKeys.indexOf('isAdmin'), 1);
+    }
+
     const updateValues = {};
     // eslint-disable-next-line no-restricted-syntax
     for (const k of updateFieldKeys) {

--- a/server/config/custom.js
+++ b/server/config/custom.js
@@ -39,6 +39,7 @@ module.exports.custom = {
   oidcScopes: process.env.OIDC_SCOPES || 'openid email profile',
   oidcAdminRoles: process.env.OIDC_ADMIN_ROLES ? process.env.OIDC_ADMIN_ROLES.split(',') : [],
   oidcRolesAttribute: process.env.OIDC_ROLES_ATTRIBUTE || 'groups',
+  oidcIgnoreRoles : process.env.OIDC_IGNORE_ROLES || false,
 
   // TODO: move client base url to environment variable?
   oidcRedirectUri: `${


### PR DESCRIPTION
Implements #533 and provides a solution to administrate users and roles in planka instead over the token claims from the oidc provider.