### PR TITLE
fix #542: Fix time format in japanese locale

### DIFF
--- a/client/src/locales/ja/core.js
+++ b/client/src/locales/ja/core.js
@@ -8,7 +8,7 @@ export default {
     time: 'HH:mm',
     dateTime: '$t(format:date) $t(format:time)',
     longDate: 'MMMMd日',
-    longDateTime: "MMMMd'日 ' HH:MM",
+    longDateTime: "MMMMd'日 ' HH:mm",
   },
 
   translation: {


### PR DESCRIPTION
Fixes issue #542

|before|after|
|---|---|
|<img width="220" alt="image" src="https://github.com/plankanban/planka/assets/34591767/559e2c94-79e6-4220-abd6-c9778bec35ec">|<img width="215" alt="image" src="https://github.com/plankanban/planka/assets/34591767/11b916f6-b629-43a4-9868-0b1acb630c71">|



