### PR TITLE
Fix containerPort to not be affected by service.port in helm

### DIFF
--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.targetPort | default 1337 }}
+              containerPort: {{ .Values.service.containerPort | default 1337 }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.service.targetPort | default 1337 }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -46,6 +46,10 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 1337
+  ## @param service.targetPort Planka HTTP container port
+  ## If empty will default to 1337
+  ##
+  targetPort: 1337
 
 ingress:
   enabled: false

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -46,10 +46,10 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 1337
-  ## @param service.targetPort Planka HTTP container port
+  ## @param service.containerPort Planka HTTP container port
   ## If empty will default to 1337
   ##
-  targetPort: 1337
+  containerPort: 1337
 
 ingress:
   enabled: false


### PR DESCRIPTION
Planka cannot be accessed if `service.port` is set to anything other than `1337`.
The cause is that the value of `service.port` is set for containerPort.

<details>
<summary>CrashLoopBackOff Error in Kubernetes:</summary>

The following example is when `service.port` is set to `80`:
```
% kubectl get svc
NAME                   TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
planka                 LoadBalancer   10.97.160.112    localhost     80:30767/TCP   93s
planka-postgresql      ClusterIP      10.111.218.220   <none>        5432/TCP       93s
planka-postgresql-hl   ClusterIP      None             <none>        5432/TCP       93s


% kubectl get po
NAME                      READY   STATUS    RESTARTS      AGE
planka-54bb896cb8-ppt4n   0/1     Running   1 (11s ago)   108s
planka-postgresql-0       1/1     Running   0             108s


% kubectl get events
LAST SEEN   TYPE      REASON              OBJECT                         MESSAGE
114s        Normal    Scheduled           pod/planka-54bb896cb8-ppt4n    Successfully assigned default/planka-54bb896cb8-ppt4n to docker-desktop
64s         Normal    Pulled              pod/planka-54bb896cb8-ppt4n    Container image "ghcr.io/plankanban/planka:1.14.3" already present on machine
92s         Normal    Created             pod/planka-54bb896cb8-ppt4n    Created container planka
92s         Normal    Started             pod/planka-54bb896cb8-ppt4n    Started container planka
64s         Warning   Unhealthy           pod/planka-54bb896cb8-ppt4n    Readiness probe failed: Get "http://10.1.0.29:80/": dial tcp 10.1.0.29:80: connect: connection refused
103s        Warning   BackOff             pod/planka-54bb896cb8-ppt4n    Back-off restarting failed container
64s         Warning   Unhealthy           pod/planka-54bb896cb8-ppt4n    Liveness probe failed: Get "http://10.1.0.29:80/": dial tcp 10.1.0.29:80: connect: connection refused
64s         Normal    Killing             pod/planka-54bb896cb8-ppt4n    Container planka failed liveness probe, will be restarted


% kubectl describe po planka-54bb896cb8-ppt4n 
Name:             planka-54bb896cb8-ppt4n
Namespace:        default
Priority:         0
Service Account:  planka
Node:             docker-desktop/192.168.65.4
Start Time:       Fri, 17 Nov 2023 23:51:28 +0900
Labels:           app.kubernetes.io/instance=planka
                  app.kubernetes.io/name=planka
                  pod-template-hash=54bb896cb8
Annotations:      <none>
Status:           Running
IP:               10.1.0.29
IPs:
  IP:           10.1.0.29
Controlled By:  ReplicaSet/planka-54bb896cb8
Containers:
  planka:
    Container ID:   docker://ce5d4f016e2e6eca74e0c446a78afed89c4239c13dd32029337939e1975e8d61
    Image:          ghcr.io/plankanban/planka:1.14.3
    Image ID:       docker-pullable://ghcr.io/plankanban/planka@sha256:3aa4eedec7085e918d7043be8bfd8ad5fbe5522f9e839bbcebcbcbaec49d7e0f
    Port:           80/TCP
    Host Port:      0/TCP
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Fri, 17 Nov 2023 23:53:29 +0900
      Finished:     Fri, 17 Nov 2023 23:53:58 +0900
    Ready:          False
...
```
</details>

---

In this PR, I've separated `service.port` and `service.containerPort`.

```yaml
# values.yaml
service:
  type: LoadBalancer
  port: 80
  containerPort: 1337
```

It works fine :)

```
% kubectl get svc
NAME                   TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
planka                 LoadBalancer   10.97.160.112    localhost     80:30767/TCP   5m
planka-postgresql      ClusterIP      10.111.218.220   <none>        5432/TCP       5m
planka-postgresql-hl   ClusterIP      None             <none>        5432/TCP       5m


% kubectl get po
NAME                      READY   STATUS    RESTARTS   AGE
planka-5dbf8b5bfd-jmcdr   1/1     Running   0          5m
planka-postgresql-0       1/1     Running   0          5m


% kubectl describe po planka-5dbf8b5bfd-jmcdr 
Name:             planka-5dbf8b5bfd-jmcdr
Namespace:        default
Priority:         0
Service Account:  planka
Node:             docker-desktop/192.168.65.4
Start Time:       Fri, 17 Nov 2023 23:52:13 +0900
Labels:           app.kubernetes.io/instance=planka
                  app.kubernetes.io/name=planka
                  pod-template-hash=5dbf8b5bfd
Annotations:      <none>
Status:           Running
IP:               10.1.0.30
IPs:
  IP:           10.1.0.30
Controlled By:  ReplicaSet/planka-5dbf8b5bfd
Containers:
  planka:
    Container ID:   docker://a3b51120153ac8eb42391b61451d3f2424e0ea76eb458ae7c834f8e3c74d5ed4
    Image:          ghcr.io/plankanban/planka:1.14.3
    Image ID:       docker-pullable://ghcr.io/plankanban/planka@sha256:3aa4eedec7085e918d7043be8bfd8ad5fbe5522f9e839bbcebcbcbaec49d7e0f
    Port:           1337/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Fri, 17 Nov 2023 23:52:14 +0900
    Ready:          True
```