### PR TITLE
fix #548: Add support for OIDC configuration thru the helm

### DIFF
--- a/charts/planka/Chart.yaml
+++ b/charts/planka/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -87,6 +87,33 @@ spec:
             - name: {{ $k | quote }}
               value: {{ $v | quote }}
           {{- end }}
+          {{- if .Values.oidc.enabled }}
+          {{- $secretName := default (printf "%s-oidc" (include "planka.fullname" .)) .Values.oidc.existingSecret }}
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key:  clientId
+                  name: {{ $secretName }}
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key:  clientSecret
+                  name: {{ $secretName }}
+            - name: OIDC_ISSUER
+              value: {{ required "issuerUrl is required when configuring OIDC" .Values.oidc.issuerUrl | quote }}
+            - name: OIDC_SCOPES
+              value: {{ join " " .Values.oidc.scopes | default "openid profile email" | quote }}
+          {{- if .Values.oidc.admin.roles }}
+            - name: OIDC_ADMIN_ROLES
+              value: {{ join "," .Values.oidc.admin.roles | quote }}
+          {{- end }}
+            - name: OIDC_ROLES_ATTRIBUTE
+              value: {{ .Values.oidc.admin.rolesAttribute | default "groups" | quote }}
+          {{- if .Values.oidc.admin.ignoreRoles }}
+            - name: OIDC_IGNORE_ROLES
+              value: {{ .Values.oidc.admin.ignoreRoles | quote }}
+          {{- end }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/planka/templates/secret-oidc.yaml
+++ b/charts/planka/templates/secret-oidc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.oidc.enabled }}
+{{- if eq (and (not (empty .Values.oidc.clientId)) (not (empty .Values.oidc.clientSecret))) (not (empty .Values.oidc.existingSecret)) -}}
+  {{- fail "Either specify inline `clientId` and `clientSecret` or refer to them via `existingSecret`" -}}
+{{- end }}
+{{- if (and (and (not (empty .Values.oidc.clientId)) (not (empty .Values.oidc.clientSecret))) (empty .Values.oidc.existingSecret)) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "planka.fullname" . }}-oidc
+  labels:
+    {{- include "planka.labels" . | nindent 4 }}
+type: Opaque
+data:
+  clientId: {{ .Values.oidc.clientId | b64enc | quote }}
+  clientSecret: {{ .Values.oidc.clientSecret | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -113,3 +113,68 @@ persistence:
   
   accessMode: ReadWriteOnce
   size: 10Gi
+
+## OpenID Identity Management configuration
+##
+## Example:
+## ---------------
+## oidc:
+##   enabled: true
+##   clientId: sxxaAIAxVXlCxTmc1YLHBbQr8NL8MqLI2DUbt42d
+##   clientSecret: om4RTMRVHRszU7bqxB7RZNkHIzA8e4sGYWxeCwIMYQXPwEBWe4SY5a0wwCe9ltB3zrq5f0dnFnp34cEHD7QSMHsKvV9AiV5Z7eqDraMnv0I8IFivmuV5wovAECAYreSI
+##   issuerUrl: https://auth.local/application/o/planka/
+##   admin:
+##     roles:
+##       - planka-admin
+##
+## ---------------
+## NOTE: A minimal configuration requires setting `clientId`, `clientSecret` and `issuerUrl`. (plus `admin.roles` for administrators)
+## ref: https://docs.planka.cloud/docs/Configuration/OIDC
+##
+oidc:
+  ## @param oidc.enabled Enable single sign-on (SSO) with OpenID Connect (OIDC)
+  ##
+  enabled: false
+
+  ## OIDC credentials
+  ## @param oidc.clientId A string unique to the provider that identifies your app.
+  ## @param oidc.clientSecret A secret string that the provider uses to confirm ownership of a client ID.
+  ##
+  ## NOTE: Either specify inline `clientId` and `clientSecret` or refer to them via `existingSecret`
+  ##
+  clientId: ""
+  clientSecret: ""
+
+  ## @param oidc.existingSecret Name of an existing secret containing OIDC credentials
+  ## NOTE: Must contain key `clientId` and `clientSecret`
+  ## NOTE: When it's set, the `clientId` and `clientSecret` parameters are ignored
+  ##
+  existingSecret: ""
+
+  ## @param oidc.issuerUrl The OpenID connect metadata document endpoint
+  ##
+  issuerUrl: ""
+
+  ## @param oidc.scopes A list of scopes required for OIDC client.
+  ## If empty will default to `openid`, `profile` and `email`
+  ## NOTE: Planka needs the email and name claims
+  ##
+  scopes: []
+
+  ## Admin permissions configuration
+  admin:
+    ## @param oidc.admin.ignoreRoles If set to true, the admin roles will be ignored.
+    ## It is useful if you want to use OIDC for authentication but not for authorization.
+    ## If empty will default to `false`
+    ##
+    ignoreRoles: false
+
+    ## @param oidc.admin.rolesAttribute The name of a custom group claim that you have configured in your OIDC provider
+    ## If empty will default to `groups`
+    ##
+    rolesAttribute: groups
+
+    ## @param oidc.admin.roles The names of the admin groups
+    ##
+    roles: []
+      # - planka-admin


### PR DESCRIPTION
In this PR, makes it easier to configure an oidc thru helm.

For example:
```yaml
oidc:
  enabled: true
  clientId: sxxaAIAxVXlCxTmc1YLHBbQr8NL8MqLI2DUbt42d
  clientSecret: om4RTMRVHRszU7bqxB7RZNkHIzA8e4sGYWxeCwIMYQXPwEBWe4SY5a0wwCe9ltB3zrq5f0dnFnp34cEHD7QSMHsKvV9AiV5Z7eqDraMnv0I8IFivmuV5wovAECAYreSI
  issuerUrl: https://auth.local/application/o/planka/
  # scopes: []
  admin:
    # ignoreRoles: false
    # rolesAttribute: groups
    roles:
      - planka-admin
```

```
% kubectl describe deploy planka
Name:                   planka
Namespace:              planka
CreationTimestamp:      Sat, 18 Nov 2023 11:10:12 +0900
Labels:                 app.kubernetes.io/instance=planka
                        app.kubernetes.io/managed-by=Helm
                        app.kubernetes.io/name=planka
                        app.kubernetes.io/version=1.15.0
                        helm.sh/chart=planka-0.1.10
Annotations:            deployment.kubernetes.io/revision: 1
                        meta.helm.sh/release-name: planka
                        meta.helm.sh/release-namespace: planka
Selector:               app.kubernetes.io/instance=planka,app.kubernetes.io/name=planka
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app.kubernetes.io/instance=planka
                    app.kubernetes.io/name=planka
  Service Account:  planka
  Containers:
   planka:
    Image:      ghcr.io/plankanban/planka:1.14.3
    Port:       1337/TCP
    Host Port:  0/TCP
    Liveness:   http-get http://:http/ delay=0s timeout=1s period=10s #success=1 #failure=3
    Readiness:  http-get http://:http/ delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:
      DATABASE_URL:            <set to the key 'uri' in secret 'planka-postgresql-svcbind-custom-user'>  Optional: false
      BASE_URL:                http://localhost
      SECRET_KEY:              PH/HcmBWzuTupMNewbIBf+1b72m234E8eTpgud9LfQkEgze3Ke4QDwlduFWn
      TRUST_PROXY:             0
      DEFAULT_ADMIN_EMAIL:     
      DEFAULT_ADMIN_PASSWORD:  
      DEFAULT_ADMIN_NAME:      
      DEFAULT_ADMIN_USERNAME:  
      OIDC_CLIENT_ID:          <set to the key 'clientId' in secret 'planka-oidc'>      Optional: false
      OIDC_CLIENT_SECRET:      <set to the key 'clientSecret' in secret 'planka-oidc'>  Optional: false
      OIDC_ISSUER:             https://auth.local/application/o/planka/
      OIDC_SCOPES:             openid profile email
      OIDC_ADMIN_ROLES:        planka-admin
      OIDC_ROLES_ATTRIBUTE:    groups
    Mounts:
       ...
```



Fixes issue #548 