### PR TITLE
feat: send emails on Comment Card notifications

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -31,6 +31,14 @@ services:
       # - DEFAULT_ADMIN_NAME=Demo Demo
       # - DEFAULT_ADMIN_USERNAME=demo
 
+      # Email Notifications (https://nodemailer.com/smtp/)
+      # - SMTP_HOST=
+      # - SMTP_PORT=587
+      # - SMTP_SECURE=true
+      # - SMTP_USER=
+      # - SMTP_PASSWORD=
+      # - SMTP_FROM="Demo Demo" <demo@demo.demo>
+
       # - OIDC_ISSUER=
       # - OIDC_CLIENT_ID=
       # - OIDC_CLIENT_SECRET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,14 @@ services:
       # - DEFAULT_ADMIN_NAME=Demo Demo
       # - DEFAULT_ADMIN_USERNAME=demo
 
+      # Email Notifications (https://nodemailer.com/smtp/)
+      # - SMTP_HOST=
+      # - SMTP_PORT=587
+      # - SMTP_SECURE=true
+      # - SMTP_USER=
+      # - SMTP_PASSWORD=
+      # - SMTP_FROM="Demo Demo" <demo@demo.demo>
+
       # - OIDC_ISSUER=
       # - OIDC_CLIENT_ID=
       # - OIDC_CLIENT_SECRET=

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -35,6 +35,14 @@ SECRET_KEY=notsecretkey
 # OIDC_IGNORE_ROLES=true
 # OIDC_ENFORCED=true
 
+# Email Notifications (https://nodemailer.com/smtp/)
+SMTP_HOST=
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_PORT=587
+SMTP_SECURE=
+SMTP_FROM="Demo Demo" <demo@demo.demo>
+
 ## Do not edit this
 
 TZ=UTC

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -22,6 +22,14 @@ SECRET_KEY=notsecretkey
 # DEFAULT_ADMIN_NAME=Demo Demo
 # DEFAULT_ADMIN_USERNAME=demo
 
+# Email Notifications (https://nodemailer.com/smtp/)
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_SECURE=true
+# SMTP_USER=
+# SMTP_PASSWORD=
+# SMTP_FROM="Demo Demo" <demo@demo.demo>
+
 # OIDC_ISSUER=
 # OIDC_CLIENT_ID=
 # OIDC_CLIENT_SECRET=
@@ -34,14 +42,6 @@ SECRET_KEY=notsecretkey
 # OIDC_IGNORE_USERNAME=true
 # OIDC_IGNORE_ROLES=true
 # OIDC_ENFORCED=true
-
-# Email Notifications (https://nodemailer.com/smtp/)
-SMTP_HOST=
-SMTP_USER=
-SMTP_PASSWORD=
-SMTP_PORT=587
-SMTP_SECURE=
-SMTP_FROM="Demo Demo" <demo@demo.demo>
 
 ## Do not edit this
 

--- a/server/api/controllers/cards/create.js
+++ b/server/api/controllers/cards/create.js
@@ -78,12 +78,12 @@ module.exports = {
   async fn(inputs) {
     const { currentUser } = this.req;
 
-    const { list } = await sails.helpers.lists
+    const { board, list } = await sails.helpers.lists
       .getProjectPath(inputs.listId)
       .intercept('pathNotFound', () => Errors.LIST_NOT_FOUND);
 
     const boardMembership = await BoardMembership.findOne({
-      boardId: list.boardId,
+      boardId: board.id,
       userId: currentUser.id,
     });
 
@@ -99,6 +99,7 @@ module.exports = {
 
     const card = await sails.helpers.cards.createOne
       .with({
+        board,
         values: {
           ...values,
           list,

--- a/server/api/controllers/comment-actions/create.js
+++ b/server/api/controllers/comment-actions/create.js
@@ -32,12 +32,12 @@ module.exports = {
   async fn(inputs) {
     const { currentUser } = this.req;
 
-    const { card } = await sails.helpers.cards
+    const { board, card } = await sails.helpers.cards
       .getProjectPath(inputs.cardId)
       .intercept('pathNotFound', () => Errors.CARD_NOT_FOUND);
 
     const boardMembership = await BoardMembership.findOne({
-      boardId: card.boardId,
+      boardId: board.id,
       userId: currentUser.id,
     });
 
@@ -55,6 +55,7 @@ module.exports = {
     };
 
     const action = await sails.helpers.actions.createOne.with({
+      board,
       values: {
         ...values,
         card,

--- a/server/api/helpers/actions/create-one.js
+++ b/server/api/helpers/actions/create-one.js
@@ -21,6 +21,10 @@ module.exports = {
       custom: valuesValidator,
       required: true,
     },
+    board: {
+      type: 'ref',
+      required: true,
+    },
     request: {
       type: 'ref',
     },
@@ -56,6 +60,9 @@ module.exports = {
             userId,
             action,
           },
+          user: values.user,
+          board: inputs.board,
+          card: values.card,
         }),
       ),
     );

--- a/server/api/helpers/cards/create-one.js
+++ b/server/api/helpers/cards/create-one.js
@@ -25,6 +25,10 @@ module.exports = {
       custom: valuesValidator,
       required: true,
     },
+    board: {
+      type: 'ref',
+      required: true,
+    },
     request: {
       type: 'ref',
     },
@@ -104,6 +108,7 @@ module.exports = {
         },
         user: values.creatorUser,
       },
+      board: inputs.board,
     });
 
     return card;

--- a/server/api/helpers/cards/update-one.js
+++ b/server/api/helpers/cards/update-one.js
@@ -232,6 +232,7 @@ module.exports = {
               toList: _.pick(values.list, ['id', 'name']),
             },
           },
+          board: inputs.board,
         });
       }
 

--- a/server/api/helpers/notifications/create-one.js
+++ b/server/api/helpers/notifications/create-one.js
@@ -1,3 +1,18 @@
+const nodemailer = require('nodemailer');
+
+const emailTransporter =
+  process.env.SMTP_HOST &&
+  nodemailer.createTransport({
+    pool: true,
+    host: process.env.SMTP_HOST,
+    port: process.env.SMTP_PORT,
+    secure: process.env.SMTP_SECURE === 'true',
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASSWORD,
+    },
+  });
+
 const valuesValidator = (value) => {
   if (!_.isPlainObject(value)) {
     return false;
@@ -13,6 +28,38 @@ const valuesValidator = (value) => {
 
   return true;
 };
+
+async function sendEmailNotification({ notification, action }) {
+  const actionUser = await sails.helpers.users.getOne(action.userId);
+  const actionCard = await Card.findOne(action.cardId);
+  const notificationUser = await sails.helpers.users.getOne(notification.userId);
+  const actionBoard = await Board.findOne(actionCard.boardId);
+  let email;
+  switch (action.type) {
+    case Action.Types.COMMENT_CARD:
+      email = {
+        subject: `${actionUser.name} commented the card ${actionCard.name} on ${actionBoard.name}`,
+        html: `<p>${actionUser.name} commented the card ${actionCard.name} on ${actionBoard.name}</p><p>${action.data.text}</p>`,
+      };
+      break;
+
+    default:
+      break;
+  }
+  if (!email) {
+    return;
+  }
+  emailTransporter.sendMail(
+    { from: process.env.SMTP_FROM, to: notificationUser.email, ...email },
+    (error, info) => {
+      if (error) {
+        sails.log.error(error);
+      } else {
+        sails.log.info('Email sent: %s', info.messageId);
+      }
+    },
+  );
+}
 
 module.exports = {
   inputs: {
@@ -35,6 +82,10 @@ module.exports = {
       actionId: values.action.id,
       cardId: values.action.cardId,
     }).fetch();
+
+    if (emailTransporter) {
+      sendEmailNotification({ notification, action: values.action });
+    }
 
     sails.sockets.broadcast(`user:${notification.userId}`, 'notificationCreate', {
       item: notification,

--- a/server/api/helpers/notifications/create-one.js
+++ b/server/api/helpers/notifications/create-one.js
@@ -46,6 +46,16 @@ async function sendEmailNotification({ notification, action }) {
           `<p>${action.data.text}</p>`,
       };
       break;
+    case Action.Types.MOVE_CARD:
+      email = {
+        subject: `${actionUser.name} moved the card ${actionCard.name} from ${action.data.fromList.name} to ${action.data.toList.name} on ${actionBoard.name}`,
+        html:
+          `<p>${actionUser.name} moved the card ` +
+          `<a href="${process.env.BASE_URL}/cards/${actionCard.id}">${actionCard.name}</a> ` +
+          `from ${action.data.fromList.name} to ${action.data.toList.name} ` +
+          `on <a href="${process.env.BASE_URL}/boards/${actionBoard.id}">${actionBoard.name}</a></p>`,
+      };
+      break;
 
     default:
       break;

--- a/server/api/helpers/notifications/create-one.js
+++ b/server/api/helpers/notifications/create-one.js
@@ -39,7 +39,11 @@ async function sendEmailNotification({ notification, action }) {
     case Action.Types.COMMENT_CARD:
       email = {
         subject: `${actionUser.name} commented the card ${actionCard.name} on ${actionBoard.name}`,
-        html: `<p>${actionUser.name} commented the card ${actionCard.name} on ${actionBoard.name}</p><p>${action.data.text}</p>`,
+        html:
+          `<p>${actionUser.name} commented the card ` +
+          `<a href="${process.env.BASE_URL}/cards/${actionCard.id}">${actionCard.name}</a> ` +
+          `on <a href="${process.env.BASE_URL}/boards/${actionBoard.id}">${actionBoard.name}</a></p>` +
+          `<p>${action.data.text}</p>`,
       };
       break;
 

--- a/server/api/helpers/utils/send-email.js
+++ b/server/api/helpers/utils/send-email.js
@@ -1,0 +1,31 @@
+module.exports = {
+  inputs: {
+    to: {
+      type: 'string',
+      required: true,
+    },
+    subject: {
+      type: 'string',
+      required: true,
+    },
+    html: {
+      type: 'string',
+      required: true,
+    },
+  },
+
+  async fn(inputs) {
+    const transporter = sails.hooks.smtp.getTransporter(); // TODO: check if active?
+
+    try {
+      const info = await transporter.sendMail({
+        ...inputs,
+        from: sails.config.custom.smtpFrom,
+      });
+
+      sails.log.info('Email sent: %s', info.messageId);
+    } catch (error) {
+      sails.log.error(error);
+    }
+  },
+};

--- a/server/api/hooks/smtp/index.js
+++ b/server/api/hooks/smtp/index.js
@@ -1,0 +1,35 @@
+const nodemailer = require('nodemailer');
+
+module.exports = function smtpServiceHook(sails) {
+  let transporter = null;
+
+  return {
+    /**
+     * Runs when this Sails app loads/lifts.
+     */
+
+    async initialize() {
+      if (sails.config.custom.smtpHost) {
+        transporter = nodemailer.createTransport({
+          pool: true,
+          host: sails.config.custom.smtpHost,
+          port: sails.config.custom.smtpPort,
+          secure: sails.config.custom.smtpSecure,
+          auth: sails.config.custom.smtpUser && {
+            user: sails.config.custom.smtpUser,
+            pass: sails.config.custom.smtpPassword,
+          },
+        });
+        sails.log.info('SMTP hook has been loaded successfully');
+      }
+    },
+
+    getTransporter() {
+      return transporter;
+    },
+
+    isActive() {
+      return transporter !== null;
+    },
+  };
+};

--- a/server/config/custom.js
+++ b/server/config/custom.js
@@ -34,6 +34,13 @@ module.exports.custom = {
   defaultAdminEmail:
     process.env.DEFAULT_ADMIN_EMAIL && process.env.DEFAULT_ADMIN_EMAIL.toLowerCase(),
 
+  smtpHost: process.env.SMTP_HOST,
+  smtpPort: process.env.SMTP_PORT || 587,
+  smtpSecure: process.env.SMTP_SECURE === 'true',
+  smtpUser: process.env.SMTP_USER,
+  smtpPassword: process.env.SMTP_PASSWORD,
+  smtpFrom: process.env.SMTP_FROM,
+
   oidcIssuer: process.env.OIDC_ISSUER,
   oidcClientId: process.env.OIDC_CLIENT_ID,
   oidcClientSecret: process.env.OIDC_CLIENT_SECRET,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "move-file": "^2.1.0",
+        "nodemailer": "^6.9.12",
         "openid-client": "^5.6.1",
         "rimraf": "^5.0.5",
         "sails": "^1.5.7",
@@ -5255,6 +5256,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.12",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.12.tgz",
+      "integrity": "sha512-pnLo7g37Br3jXbF0bl5DekBJihm2q+3bB3l2o/B060sWmb5l+VqeScAQCBqaQ+5ezRZFzW5SciZNGdRDEbq89w==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -12851,6 +12860,11 @@
       "requires": {
         "whatwg-url": "^5.0.0"
       }
+    },
+    "nodemailer": {
+      "version": "6.9.12",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.12.tgz",
+      "integrity": "sha512-pnLo7g37Br3jXbF0bl5DekBJihm2q+3bB3l2o/B060sWmb5l+VqeScAQCBqaQ+5ezRZFzW5SciZNGdRDEbq89w=="
     },
     "nodemon": {
       "version": "3.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -36,6 +36,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "move-file": "^2.1.0",
+    "nodemailer": "^6.9.12",
     "openid-client": "^5.6.1",
     "rimraf": "^5.0.5",
     "sails": "^1.5.7",


### PR DESCRIPTION
Sends emails to notification receivers on Comment Card actions.

**New env vars**
```
SMTP_HOST=
SMTP_USER=
SMTP_PASSWORD=
SMTP_PORT=587
SMTP_SECURE=
SMTP_FROM="Demo Demo" <demo@demo.demo>
```

More action types could be supported in a similar way.

**This adds [nodemailer](https://nodemailer.com) as a dependency**

