### PR TITLE
fix: Allow specifying an external dburl in helm

### DIFF
--- a/charts/planka/Chart.yaml
+++ b/charts/planka/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.21
+version: 0.1.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -58,11 +58,16 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+          {{- if not .Values.postgresql.enabled }}
+            - name: DATABASE_URL
+              value: {{ required "If the included postgresql deployment is disabled you need to define a Database URL in 'dburl'" .Values.dburl }}
+          {{- else }}
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: planka-postgresql-svcbind-custom-user
                   key: uri
+          {{- end }}
             - name: BASE_URL
               {{- if .Values.baseUrl }}
               value: {{ .Values.baseUrl }}

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -105,12 +105,14 @@ postgresql:
   serviceBindings:
     enabled: true
 
+## Set this if you disable the built-in postgresql deployment
+dburl:
+
 ## PVC-based data storage configuration
 persistence:
   enabled: false
   # existingClaim: netbox-data
   # storageClass: "-"
-  
   accessMode: ReadWriteOnce
   size: 10Gi
 


### PR DESCRIPTION
Some helm users might want to turn off the built-in postgres installation, but the deployment template statically refers to a secret created by the postgresql chart.

If postgres.enabled is set to false, we should ask for a dburl parameter for an external postgres and use that in the environment instead.

The behavior if postgres.enabled == true remains unchanged.