### PR TITLE
Use docker/metadata-action to make sure all opencontainer labels are set

### DIFF
--- a/.github/workflows/build-and-push-docker-base-image.yml
+++ b/.github/workflows/build-and-push-docker-base-image.yml
@@ -40,5 +40,5 @@ jobs:
           build-args: ALPINE_VERSION=${{ env.ALPINE_VERSION }}
           push: true
           tags: |
-            ghcr.io/plankanban/planka:base-latest
-            ghcr.io/plankanban/planka:base-${{ env.ALPINE_VERSION }}
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:base-latest
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:base-${{ env.ALPINE_VERSION }}

--- a/.github/workflows/build-and-push-docker-image-dev.yml
+++ b/.github/workflows/build-and-push-docker-image-dev.yml
@@ -11,7 +11,7 @@ on:
     branches: [master]
 
 env:
-  REGISTRY_IMAGE: ghcr.io/plankanban/planka
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
 
 jobs:
   build:

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -31,12 +31,21 @@ jobs:
           result-encoding: string
           script: return context.payload.release.tag_name.replace('v', '')
 
+      - name: Generate docker image tags
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ steps.set-version.outputs.result }}
+            type=raw,value=latest
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          tags: |
-            ghcr.io/plankanban/planka:latest
-            ghcr.io/plankanban/planka:${{ steps.set-version.outputs.result }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -49,3 +49,5 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
I use renovate to make sure my deployed apps are up to date. ([see](https://github.com/halkeye/home-k8s/pull/94)) and according to the [documentation](https://docs.renovatebot.com/modules/datasource/docker/) if the source docker label is set, it'll actually pull in the release notes.

I checked the latest release, and it doesn't seem to have the labels (or any labels) set, so using the pre-existing github action should populate all the nice metadata.

```
regctl image config --format '{{ jsonPretty .Config.Labels }}' ghcr.io/plankanban/planka
null
```