### PR TITLE
fix: Helm: Add a volumemount for the logs subpath

### DIFF
--- a/charts/planka/Chart.yaml
+++ b/charts/planka/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.23
+version: 0.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             - mountPath: /app/private/attachments
               subPath: attachments
               name: planka
+            - mountPath: /app/logs
+              subPath: logs
+              name: planka
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:


### PR DESCRIPTION
If we run on Openshift, the container is launched read-only causing a Permission Denied error when the planka pod starts up and tries to make the logs directory. If we add 'logs' as a volumemount we can write to it.

I'm open to some discussion here if there's a reason to leave logs out of the storage configuration.