### PR TITLE
feat: Ensure container can run with readOnlyRootFilesystem

### DIFF
--- a/charts/planka/Chart.yaml
+++ b/charts/planka/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.23
+version: 0.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -55,6 +55,11 @@ spec:
             - mountPath: /app/private/attachments
               subPath: attachments
               name: planka
+          {{- if .Values.securityContext.readOnlyRootFilesystem }}
+            - mountPath: /app/logs
+              subPath: app-logs
+              name: emptydir
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
@@ -139,3 +144,7 @@ spec:
     {{- else }}
           emptyDir: {}
     {{- end }}
+    {{- if .Values.securityContext.readOnlyRootFilesystem }}
+        - name: emptydir
+          emptyDir: {}
+     {{- end }}


### PR DESCRIPTION
This PR succeds https://github.com/plankanban/planka/pull/681

When `securityContext.readOnlyRootFilesystem: true`  is true, an emptyDir volumeMount is added. 
This is an ephemeral storage location for the contents of `/app/logs`  