### PR TITLE
Enable ability for DBURI to be an existing secret

### DIFF
--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -64,8 +64,16 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
           {{- if not .Values.postgresql.enabled }}
+          {{- if .Values.existingDburlSecret }}
             - name: DATABASE_URL
-              value: {{ required "If the included postgresql deployment is disabled you need to define a Database URL in 'dburl'" .Values.dburl }}
+              valueFrom:
+                secretKeyRef:
+                  name: .Values.existingDburlSecret
+                  key: uri
+          {{- else }}
+            - name: DATABASE_URL
+              value: {{ required "If the included postgresql deployment is disabled you need to provide an existing secret in .Values.existingDburlSecret or define a Database URL in 'dburl'" .Values.dburl }}
+          {{- end }}
           {{- else }}
             - name: DATABASE_URL
               valueFrom:

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -105,8 +105,14 @@ postgresql:
   serviceBindings:
     enabled: true
 
-## Set this if you disable the built-in postgresql deployment
+## Set this or existingDburlSecret if you disable the built-in postgresql deployment
 dburl:
+
+## @param existingDburlSecret Name of an existing secret containing a DBurl connection string
+## NOTE: Must contain key `uri`
+## NOTE: When it's set, the `dburl` parameter is ignored
+##
+existingDburlSecret: ""
 
 ## PVC-based data storage configuration
 persistence:


### PR DESCRIPTION
Hey, 

This is hopefully a nice and simple PR.  This resolves https://github.com/plankanban/planka/issues/750 by adding an `existingDburlSecret` field to replace the `dburl` if provided to securely pass the connection string into the environment. 

I am not quite sure if i am happy with the naming of the variables etc in the top level but it was the closest I could come up with to match similar https://github.com/plankanban/planka/blob/master/charts/planka/values.yaml#L154 values. 

I feel like it might work nicer to nest this parameter within the `postgres` object for consistency but either option works for my use case. 

I have a helm playground [here](https://helm-playground.com/#t=AQ1imB2BuBcBQYnAN4oLTAJYDNiQHsAXYAOgDUBDAGwFdwBnUgBwIaIHMAnRgR2tJRKAI2rgAJsAC%2BUxMlBpMuMlTqNBADyzsskDgBFhtLtQDK4AMY8SMufNCZIlALbhYwfQEEAKp4BCnqYAogD6AKoASgAydvag0DT0AGJcBM4IcfIMltYA0uAAnhHgOBmZ8k6u7hSJ6uBaOnqGxmY54ESx5aAA1oXuxlidSIrA4NTZ0rJdji5uHj7%2BgaGRMV0gCWruaMA8vLRYPJIARACSeEQAFuDYkBZ04hLArOzcfNTAD8zUBAWukCTaD7aERiSQFAi0fDgR5EAhPVLQLAPYCUSCjBpEXQcYDZKztG4qWpMeraTFNIwmcx4kgELgfEq6a6UDyUIgiSgTFYEgDk4gp1G5R0JaiYfJakyGYBGUEktky0vG1zl5RmVXmvgCwXC0Ul8g2yVS6V19lxeUKxVKxrilTmX1R3Uo6GenB4DH46AY0Aswl04nQFlo7DS6ED4C4VvsvQK-S4g3lGFGkFlUxV%2BFm7k1yx1a1QCeUNRFpGEHPAYRMEpz%2Brm2wL9CYxeyZfeyq60qTkyAA&v=MQUwHglgzgLhB2BzAIgIwK4CcA2BlEAxpiDAFwAEARFAPYC2JAFgogLSMjGUBQAJhjgqVc6AA6d8BLCFwxMLHqgCGUEAFVB5VNiWMAdKJ3wA1kr0F6QA) that tests out the proposed changes 

<img width="1524" alt="image" src="https://github.com/plankanban/planka/assets/7417605/06c54cfd-7695-4d6d-ac47-ff7c7e936ddf">


Let me know if you have any question or you would like me to make any other modifications to the PR