### PR TITLE
Fix Helm template for DBURI Secret

### DIFF
--- a/charts/planka/Chart.yaml
+++ b/charts/planka/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.31
+version: 0.1.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: .Values.existingDburlSecret
+                  name: {{ .Values.existingDburlSecret }}
                   key: uri
           {{- else }}
             - name: DATABASE_URL


### PR DESCRIPTION
A fix to https://github.com/plankanban/planka/issues/750 

The helm playground accepted the variable without the `{{ }}` but it appears that was not valid. This should hopefully render the template properly 