### PR TITLE
Fix : Wrong path to socket.io in production mode #768

### DIFF
--- a/client/src/api/socket.js
+++ b/client/src/api/socket.js
@@ -13,7 +13,7 @@ io.sails.environment = process.env.NODE_ENV;
 
 const { socket } = io;
 
-socket.path = `${Config.BASE_PATH}/socket.io`;
+socket.path = `${Config.SERVER_BASE_PATH}/socket.io`;
 socket.connect = socket._connect; // eslint-disable-line no-underscore-dangle
 
 ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].forEach((method) => {

--- a/client/src/constants/Config.js
+++ b/client/src/constants/Config.js
@@ -6,6 +6,7 @@ const BASE_PATH = BASE_URL.replace(/^.*\/\/[^/]*(.*)[^?#]*.*$/, '$1');
 const SERVER_BASE_URL =
   process.env.REACT_APP_SERVER_BASE_URL ||
   (process.env.NODE_ENV === 'production' ? BASE_URL : 'http://localhost:1337');
+const SERVER_BASE_PATH = SERVER_BASE_URL.replace(/^.*\/\/[^/]*(.*)[^?#]*.*$/, '$1');
 
 const SERVER_HOST_NAME = SERVER_BASE_URL.replace(/^(.*\/\/[^/?#]*).*$/, '$1');
 
@@ -20,6 +21,7 @@ export default {
   VERSION,
   BASE_PATH,
   SERVER_BASE_URL,
+  SERVER_BASE_PATH,
   SERVER_HOST_NAME,
   ACCESS_TOKEN_KEY,
   ACCESS_TOKEN_VERSION_KEY,


### PR DESCRIPTION
Fix the issue : Wrong path to socket.io in production mode when client and server are different #768 

It occurs when trying to deploy planka with different directories, such as :
- server is accessed at https://xxxx/tasks
- client is accessed at https://xxxx/planka
