### PR TITLE
feat: :children_crossing: enhance edit usability

### DIFF
--- a/client/src/components/Card/NameEdit.jsx
+++ b/client/src/components/Card/NameEdit.jsx
@@ -5,6 +5,7 @@ import TextareaAutosize from 'react-textarea-autosize';
 import { Button, Form, TextArea } from 'semantic-ui-react';
 
 import { useClosableForm, useField } from '../../hooks';
+import { focusEnd } from '../../utils/element-helpers';
 
 import styles from './NameEdit.module.scss';
 
@@ -79,9 +80,7 @@ const NameEdit = React.forwardRef(({ children, defaultValue, onUpdate }, ref) =>
 
   useEffect(() => {
     if (isOpened) {
-      const text = field.current.ref.current;
-      text.focus();
-      text.setSelectionRange(text.value.length + 1, text.value.length + 1);
+      focusEnd(field.current.ref.current);
     }
   }, [isOpened]);
 

--- a/client/src/components/Card/NameEdit.jsx
+++ b/client/src/components/Card/NameEdit.jsx
@@ -79,7 +79,9 @@ const NameEdit = React.forwardRef(({ children, defaultValue, onUpdate }, ref) =>
 
   useEffect(() => {
     if (isOpened) {
-      field.current.ref.current.focus();
+      const text = field.current.ref.current;
+      text.focus();
+      text.setSelectionRange(text.value.length + 1, text.value.length + 1);
     }
   }, [isOpened]);
 

--- a/client/src/components/CardModal/Activities/CommentEdit.jsx
+++ b/client/src/components/CardModal/Activities/CommentEdit.jsx
@@ -6,6 +6,7 @@ import TextareaAutosize from 'react-textarea-autosize';
 import { Button, Form, TextArea } from 'semantic-ui-react';
 
 import { useForm } from '../../../hooks';
+import { focusEnd } from '../../../utils/element-helpers';
 
 import styles from './CommentEdit.module.scss';
 
@@ -70,9 +71,7 @@ const CommentEdit = React.forwardRef(({ children, defaultData, onUpdate }, ref) 
 
   useEffect(() => {
     if (isOpened) {
-      const text = textField.current.ref.current;
-      text.focus();
-      text.setSelectionRange(text.value.length + 1, text.value.length + 1);
+      focusEnd(textField.current.ref.current);
     }
   }, [isOpened]);
 

--- a/client/src/components/CardModal/Activities/CommentEdit.jsx
+++ b/client/src/components/CardModal/Activities/CommentEdit.jsx
@@ -70,7 +70,9 @@ const CommentEdit = React.forwardRef(({ children, defaultData, onUpdate }, ref) 
 
   useEffect(() => {
     if (isOpened) {
-      textField.current.ref.current.focus();
+      const text = textField.current.ref.current;
+      text.focus();
+      text.setSelectionRange(text.value.length + 1, text.value.length + 1);
     }
   }, [isOpened]);
 

--- a/client/src/components/CardModal/Tasks/NameEdit.jsx
+++ b/client/src/components/CardModal/Tasks/NameEdit.jsx
@@ -65,7 +65,9 @@ const NameEdit = React.forwardRef(({ children, defaultValue, onUpdate }, ref) =>
 
   useEffect(() => {
     if (isOpened) {
-      field.current.ref.current.focus();
+      const text = field.current.ref.current;
+      text.focus();
+      text.setSelectionRange(text.value.length + 1, text.value.length + 1);
     }
   }, [isOpened]);
 

--- a/client/src/components/CardModal/Tasks/NameEdit.jsx
+++ b/client/src/components/CardModal/Tasks/NameEdit.jsx
@@ -5,6 +5,7 @@ import TextareaAutosize from 'react-textarea-autosize';
 import { Button, Form, TextArea } from 'semantic-ui-react';
 
 import { useField } from '../../../hooks';
+import { focusEnd } from '../../../utils/element-helpers';
 
 import styles from './NameEdit.module.scss';
 
@@ -65,9 +66,7 @@ const NameEdit = React.forwardRef(({ children, defaultValue, onUpdate }, ref) =>
 
   useEffect(() => {
     if (isOpened) {
-      const text = field.current.ref.current;
-      text.focus();
-      text.setSelectionRange(text.value.length + 1, text.value.length + 1);
+      focusEnd(field.current.ref.current);
     }
   }, [isOpened]);
 

--- a/client/src/components/List/NameEdit.jsx
+++ b/client/src/components/List/NameEdit.jsx
@@ -71,7 +71,9 @@ const NameEdit = React.forwardRef(({ children, defaultValue, onUpdate }, ref) =>
 
   useEffect(() => {
     if (isOpened) {
-      field.current.ref.current.select();
+      const text = field.current.ref.current;
+      text.focus();
+      text.setSelectionRange(text.value.length + 1, text.value.length + 1);
     }
   }, [isOpened]);
 

--- a/client/src/components/List/NameEdit.jsx
+++ b/client/src/components/List/NameEdit.jsx
@@ -4,6 +4,7 @@ import TextareaAutosize from 'react-textarea-autosize';
 import { TextArea } from 'semantic-ui-react';
 
 import { useField } from '../../hooks';
+import { focusEnd } from '../../utils/element-helpers';
 
 import styles from './NameEdit.module.scss';
 
@@ -71,9 +72,7 @@ const NameEdit = React.forwardRef(({ children, defaultValue, onUpdate }, ref) =>
 
   useEffect(() => {
     if (isOpened) {
-      const text = field.current.ref.current;
-      text.focus();
-      text.setSelectionRange(text.value.length + 1, text.value.length + 1);
+      focusEnd(field.current.ref.current);
     }
   }, [isOpened]);
 

--- a/client/src/utils/element-helpers.js
+++ b/client/src/utils/element-helpers.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const focusEnd = (element) => {
+  element.focus();
+  element.setSelectionRange(element.value.length + 1, element.value.length + 1);
+};


### PR DESCRIPTION
When editing certain fields on the client, the cursor currently defaults to the beginning of the text. Based on my personal experience, it is more intuitive for the cursor to be positioned at the end of the text.

I've attached a video demonstrating the old and new behaviour:

[screen-capture.webm](https://github.com/plankanban/planka/assets/16878981/34a39eb2-fc20-4d6b-8933-2b215f0027a1)

Cheers
Hannes
