### PR TITLE
Handle WEBHOOKS env variable being unset

### DIFF
--- a/server/config/custom.js
+++ b/server/config/custom.js
@@ -60,7 +60,7 @@ module.exports.custom = {
   smtpPassword: process.env.SMTP_PASSWORD,
   smtpFrom: process.env.SMTP_FROM,
 
-  webhooks: JSON.parse(process.env.WEBHOOKS), // TODO: validate structure
+  webhooks: JSON.parse(process.env.WEBHOOKS || '[]'), // TODO: validate structure
 
   slackBotToken: process.env.SLACK_BOT_TOKEN,
   slackChannelId: process.env.SLACK_CHANNEL_ID,


### PR DESCRIPTION
Fixes #784 by defining it to be an empty array so it properly parses/sets to config.