### PR TITLE
fix: :bug: clean catch possible rejected promise

### DIFF
--- a/server/api/helpers/utils/send-webhooks.js
+++ b/server/api/helpers/utils/send-webhooks.js
@@ -97,7 +97,9 @@ module.exports = {
         return;
       }
 
-      sendWebhook(webhook, inputs.event, inputs.data, inputs.user);
+      sendWebhook(webhook, inputs.event, inputs.data, inputs.user).catch((error) => {
+        sails.log.error(`Failed to send webhook ${webhook.url}`, error);
+      });
     });
   },
 };


### PR DESCRIPTION
Improvement on catching rejected promise if the fetch API rejects, as pointed out as one possible improvement in feature request: https://github.com/plankanban/planka/issues/793

(I'm not sure if sails nicely handle/logs the rejected async event loops by themself, if so please feel free to close the pull request)