### PR TITLE
docs: :label: add types to webhook function

### DIFF
--- a/server/api/helpers/utils/send-webhooks.js
+++ b/server/api/helpers/utils/send-webhooks.js
@@ -23,11 +23,25 @@ const jsonifyData = (data) => {
 };
 
 /**
+ * @typedef {Object} Included
+ * @property {any[]} [projects] - Array of projects (optional).
+ * @property {any[]} [boards] - Array of boards (optional).
+ * @property {any[]} [lists] - Array of lists (optional).
+ * @property {any[]} [cards] - Array of cards (optional).
+ */
+
+/**
+ * @typedef {Object} Data
+ * @property {any} item - Actual event data.
+ * @property {Included} [included] - Optional included data.
+ */
+
+/**
  * Sends a webhook notification to a configured URL.
  *
  * @param {*} webhook - Webhook configuration.
  * @param {string} event - The event (see {@link Events}).
- * @param {*} data - The actual data related to the event.
+ * @param {Data} data - The data object containing event data and optionally included data.
  * @param {ref} user - User object associated with the event.
  * @returns {Promise<void>}
  */


### PR DESCRIPTION
This adds very basic types to the webhook function, so one can create programatically types for a payload on the webhook: https://github.com/plankanban/planka/issues/793