### PR TITLE
feat: :sparkles: add custom user agent to webhook with base url

### DIFF
--- a/server/api/helpers/utils/send-webhooks.js
+++ b/server/api/helpers/utils/send-webhooks.js
@@ -34,6 +34,7 @@ const jsonifyData = (data) => {
 async function sendWebhook(webhook, event, data, user) {
   const headers = {
     'Content-Type': 'application/json',
+    'User-Agent': `planka (+${sails.config.custom.baseUrl})`,
   };
 
   if (webhook.accessToken) {


### PR DESCRIPTION
This update adds a default `user-agent` to the header, which includes the base URL. This enhancement allows for differentiating multiple instances on the webhook and creating links to events without hardcoding any base URLs.

Prior to this change, the default user-agent of node-fetch was "node".

Cheers,
Hannes