### PR TITLE
Sort users by name in boards, cards and user list

### DIFF
--- a/client/src/models/Board.js
+++ b/client/src/models/Board.js
@@ -219,7 +219,12 @@ export default class extends BaseModel {
   }
 
   getOrderedMembershipsQuerySet() {
-    return this.memberships.orderBy('createdAt');
+    return this.memberships.orderBy((membership) =>
+      this.memberUsers
+        .toModelArray()
+        .filter((user) => user.id === membership.userId)[0]
+        .name.toLocaleLowerCase(),
+    );
   }
 
   getOrderedLabelsQuerySet() {

--- a/client/src/models/User.js
+++ b/client/src/models/User.js
@@ -298,7 +298,7 @@ export default class extends BaseModel {
   static getOrderedUndeletedQuerySet() {
     return this.filter({
       deletedAt: null,
-    }).orderBy('createdAt');
+    }).orderBy((u) => u.name.toLocaleLowerCase());
   }
 
   getOrderedProjectManagersQuerySet() {


### PR DESCRIPTION
This fix sorts users by name (lower cased) in list that appears in boards, cards and the admin list for users.