### PR TITLE
Enhance OIDC Support for Compatibility with Strict Providers

### DIFF
--- a/server/api/controllers/access-tokens/exchange-using-oidc.js
+++ b/server/api/controllers/access-tokens/exchange-using-oidc.js
@@ -13,6 +13,9 @@ const Errors = {
   MISSING_VALUES: {
     missingValues: 'Unable to retrieve required values (email, name)',
   },
+  INVALID_USERINFO_SIGNATURE: {
+    invalidUserInfoSignature: "Invalid signature on userInfo due to client misconfiguration"
+  }
 };
 
 module.exports = {
@@ -40,6 +43,9 @@ module.exports = {
     missingValues: {
       responseType: 'unprocessableEntity',
     },
+    invalidUserInfoSignature: {
+      responseType: 'unauthorized',
+    },
   },
 
   async fn(inputs) {
@@ -51,6 +57,7 @@ module.exports = {
         sails.log.warn(`Invalid code or nonce! (IP: ${remoteAddress})`);
         return Errors.INVALID_CODE_OR_NONCE;
       })
+      .intercept('invalidUserInfoSignature', () => Errors.INVALID_USERINFO_SIGNATURE)
       .intercept('emailAlreadyInUse', () => Errors.EMAIL_ALREADY_IN_USE)
       .intercept('usernameAlreadyInUse', () => Errors.USERNAME_ALREADY_IN_USE)
       .intercept('missingValues', () => Errors.MISSING_VALUES);

--- a/server/api/controllers/show-config.js
+++ b/server/api/controllers/show-config.js
@@ -4,11 +4,16 @@ module.exports = {
     if (sails.hooks.oidc.isActive()) {
       const oidcClient = sails.hooks.oidc.getClient();
 
+      const authorizationParameters = {
+        scope: sails.config.custom.oidcScopes,
+      }
+
+      if(!sails.config.custom.oidcDefaultResponseMode) {
+        authorizationParameters.response_mode = sails.config.custom.oidcResponseMode
+      }
+
       oidc = {
-        authorizationUrl: oidcClient.authorizationUrl({
-          scope: sails.config.custom.oidcScopes,
-          response_mode: 'fragment',
-        }),
+        authorizationUrl: oidcClient.authorizationUrl(authorizationParameters),
         endSessionUrl: oidcClient.issuer.end_session_endpoint ? oidcClient.endSessionUrl({}) : null,
         isEnforced: sails.config.custom.oidcEnforced,
       };

--- a/server/api/helpers/users/get-or-create-one-using-oidc.js
+++ b/server/api/helpers/users/get-or-create-one-using-oidc.js
@@ -11,6 +11,7 @@ module.exports = {
   },
 
   exits: {
+    invalidUserInfoSignature: {},
     invalidCodeOrNonce: {},
     missingValues: {},
     emailAlreadyInUse: {},
@@ -34,6 +35,10 @@ module.exports = {
       );
       userInfo = await client.userinfo(tokenSet);
     } catch (e) {
+      if (e instanceof SyntaxError && e.message.includes('Unexpected token e in JSON at position 0')) {
+        sails.log.warn('Error while exchanging OIDC code: userInfo response is signed.');
+        throw 'invalidUserInfoSignature';
+      }
       sails.log.warn(`Error while exchanging OIDC code: ${e}`);
       throw 'invalidCodeOrNonce';
     }

--- a/server/api/hooks/oidc/index.js
+++ b/server/api/hooks/oidc/index.js
@@ -30,6 +30,7 @@ module.exports = function defineOidcHook(sails) {
         client_secret: sails.config.custom.oidcClientSecret,
         redirect_uris: [sails.config.custom.oidcRedirectUri],
         response_types: ['code'],
+        userinfo_signed_response_alg: sails.config.custom.oidcUserinfoSignedResponseAlg,
       });
     },
 

--- a/server/api/hooks/oidc/index.js
+++ b/server/api/hooks/oidc/index.js
@@ -25,13 +25,19 @@ module.exports = function defineOidcHook(sails) {
 
       const issuer = await openidClient.Issuer.discover(sails.config.custom.oidcIssuer);
 
-      client = new issuer.Client({
+      const metadata = {
         client_id: sails.config.custom.oidcClientId,
         client_secret: sails.config.custom.oidcClientSecret,
         redirect_uris: [sails.config.custom.oidcRedirectUri],
         response_types: ['code'],
         userinfo_signed_response_alg: sails.config.custom.oidcUserinfoSignedResponseAlg,
-      });
+      }
+
+      if (sails.config.custom.oidcIdTokenSignedResponseAlg) {
+        metadata.id_token_signed_response_alg = sails.config.custom.oidcIdTokenSignedResponseAlg
+      }
+
+      client = new issuer.Client(metadata);
     },
 
     getClient() {

--- a/server/config/custom.js
+++ b/server/config/custom.js
@@ -39,6 +39,7 @@ module.exports.custom = {
   oidcIssuer: process.env.OIDC_ISSUER,
   oidcClientId: process.env.OIDC_CLIENT_ID,
   oidcClientSecret: process.env.OIDC_CLIENT_SECRET,
+  oidcUserinfoSignedResponseAlg: process.env.OIDC_USERINFO_SIGNED_RESPONSE_ALG,
   oidcScopes: process.env.OIDC_SCOPES || 'openid email profile',
   oidcResponseMode: process.env.OIDC_RESPONSE_MODE || 'fragment',
   oidcDefaultResponseMode: process.env.OIDC_DEFAULT_RESPONSE_MODE === 'true',

--- a/server/config/custom.js
+++ b/server/config/custom.js
@@ -40,6 +40,8 @@ module.exports.custom = {
   oidcClientId: process.env.OIDC_CLIENT_ID,
   oidcClientSecret: process.env.OIDC_CLIENT_SECRET,
   oidcScopes: process.env.OIDC_SCOPES || 'openid email profile',
+  oidcResponseMode: process.env.OIDC_RESPONSE_MODE || 'fragment',
+  oidcDefaultResponseMode: process.env.OIDC_DEFAULT_RESPONSE_MODE === 'true',
   oidcAdminRoles: process.env.OIDC_ADMIN_ROLES ? process.env.OIDC_ADMIN_ROLES.split(',') : [],
   oidcEmailAttribute: process.env.OIDC_EMAIL_ATTRIBUTE || 'email',
   oidcNameAttribute: process.env.OIDC_NAME_ATTRIBUTE || 'name',

--- a/server/config/custom.js
+++ b/server/config/custom.js
@@ -39,6 +39,7 @@ module.exports.custom = {
   oidcIssuer: process.env.OIDC_ISSUER,
   oidcClientId: process.env.OIDC_CLIENT_ID,
   oidcClientSecret: process.env.OIDC_CLIENT_SECRET,
+  oidcIdTokenSignedResponseAlg: process.env.OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG,
   oidcUserinfoSignedResponseAlg: process.env.OIDC_USERINFO_SIGNED_RESPONSE_ALG,
   oidcScopes: process.env.OIDC_SCOPES || 'openid email profile',
   oidcResponseMode: process.env.OIDC_RESPONSE_MODE || 'fragment',


### PR DESCRIPTION
I am working for the French government, which employs a very strict OIDC provider. Government applications often adhere to more stringent implementations of the OIDC specification to enhance security.

To properly connect Planka with their OIDC provider, I needed to add greater flexibility to the current openid-client integration. The initial implementation was missing some important features, such as support for signed user info.

Given the nature of this work, it's crucial to clearly explain every change, I tried to be as explicit as possible in my commits.

Here's a summary:
- Allow using the default value of `response_mode` or specifying a custom value without introducing breaking changes.
- Ensure the client can handle signed user info responses from strict OIDC providers.
- Expand Supported Signing Algorithms, by supporting more signing algorithms than just 'RS256' for the ID token endpoint.
