### PR TITLE
Update user and db  for healthcheck docker-compose-dev.yml

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -117,7 +117,7 @@ services:
       - "5432:5432"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d planka"]
+      test: ["CMD-SHELL", "pg_isready -U user -d planka_db"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Currently docker dev postgres fails because the healthcheck uses an account and db which has not been initialised. This PR updates the username and the db so that correct credentials are used