### PR TITLE
feat: Change the update strategy in case of persistence

### DIFF
--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "planka.selectorLabels" . | nindent 6 }}
+  {{- if .Values.persistence.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
In case planka is installed with a PV associated to the planka pod, to persist attachments and avatars for example, the default update strategy for the deployment will fail. The default "rolling update" strategy would indeed try to start a new pod before stopping the old one. But as the PV is attached to the old pod,  the new pod will fail to attach and so will stay in "container creating" mode, and the old pod will never be stopped.

To avoid that, adding a condition on the deployment to use the "recreate" update strategy if the persistence is enabled. This will ensure the old pod is stopped and so the PV is detached  before trying to attach the new one.