### PR TITLE
feat: Add multi-task creation with Ctrl+Enter in Add.jsx

### DIFF
--- a/client/src/components/CardModal/Tasks/Add.jsx
+++ b/client/src/components/CardModal/Tasks/Add.jsx
@@ -13,6 +13,8 @@ const DEFAULT_DATA = {
   name: '',
 };
 
+const MULTIPLE_REGEX = /\s*\r?\n\s*/;
+
 const Add = React.forwardRef(({ children, onCreate }, ref) => {
   const [t] = useTranslation();
   const [isOpened, setIsOpened] = useState(false);
@@ -29,22 +31,34 @@ const Add = React.forwardRef(({ children, onCreate }, ref) => {
     setIsOpened(false);
   }, []);
 
-  const submit = useCallback(() => {
-    const cleanData = {
-      ...data,
-      name: data.name.trim(),
-    };
+  const submit = useCallback(
+    (isMultiple = false) => {
+      const cleanData = {
+        ...data,
+        name: data.name.trim(),
+      };
 
-    if (!cleanData.name) {
-      nameField.current.ref.current.select();
-      return;
-    }
+      if (!cleanData.name) {
+        nameField.current.ref.current.select();
+        return;
+      }
 
-    onCreate(cleanData);
+      if (isMultiple) {
+        cleanData.name.split(MULTIPLE_REGEX).forEach((name) => {
+          onCreate({
+            ...cleanData,
+            name,
+          });
+        });
+      } else {
+        onCreate(cleanData);
+      }
 
-    setData(DEFAULT_DATA);
-    focusNameField();
-  }, [onCreate, data, setData, focusNameField]);
+      setData(DEFAULT_DATA);
+      focusNameField();
+    },
+    [onCreate, data, setData, focusNameField],
+  );
 
   useImperativeHandle(
     ref,
@@ -61,17 +75,12 @@ const Add = React.forwardRef(({ children, onCreate }, ref) => {
 
   const handleFieldKeyDown = useCallback(
     (event) => {
-      if (event.ctrlKey && event.key === 'Enter') {
+      if (event.key === 'Enter') {
         event.preventDefault();
-        const lines = data.name.split('\n').filter(line => line.trim() !== '');
-        lines.forEach(line => onCreate({ name: line.trim() }));
-        setData({ ...data, name: '' });
-      } else if (event.key === 'Enter') {
-        event.preventDefault();
-        submit();
+        submit(event.ctrlKey);
       }
     },
-    [data, onCreate, submit],
+    [submit],
   );
 
   const [handleFieldBlur, handleControlMouseOver, handleControlMouseOut] = useClosableForm(

--- a/client/src/components/CardModal/Tasks/Add.jsx
+++ b/client/src/components/CardModal/Tasks/Add.jsx
@@ -61,13 +61,17 @@ const Add = React.forwardRef(({ children, onCreate }, ref) => {
 
   const handleFieldKeyDown = useCallback(
     (event) => {
-      if (event.key === 'Enter') {
+      if (event.ctrlKey && event.key === 'Enter') {
         event.preventDefault();
-
+        const lines = data.name.split('\n').filter(line => line.trim() !== '');
+        lines.forEach(line => onCreate({ name: line.trim() }));
+        setData({ ...data, name: '' });
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
         submit();
       }
     },
-    [submit],
+    [data, onCreate, submit],
   );
 
   const [handleFieldBlur, handleControlMouseOver, handleControlMouseOut] = useClosableForm(


### PR DESCRIPTION
Modified the handleFieldKeyDown function in Add.jsx to handle Ctrl+Enter keypress events. This change allows creating multiple tasks from each non-empty line in the text field when Ctrl+Enter is pressed, while maintaining the existing functionality for creating a single task on Enter.

A similar feature is in Trello, which I find essential when copy-pasting a list of items and want them to be multiple tasks and not just a huge single task.