### PR TITLE
fix: Use planka.fullname for postgres secret name

### DIFF
--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: planka-postgresql-svcbind-custom-user
+                  name: {{ include "planka.fullname" . }}-postgresql-svcbind-custom-user
                   key: uri
           {{- end }}
             - name: BASE_URL


### PR DESCRIPTION
Honor helm releaseName and fullnameOverride for bitnami postgres secrets - fixes #704

This little helm chart modification makes sure custom release names and fullnameOverride does work.
I tested it on my planka-deployment.

Fixes #704 