### PR TITLE
fix: Lazy initialize OIDC client

### DIFF
--- a/server/api/controllers/access-tokens/exchange-using-oidc.js
+++ b/server/api/controllers/access-tokens/exchange-using-oidc.js
@@ -6,6 +6,9 @@ const Errors = {
   INVALID_CODE_OR_NONCE: {
     invalidCodeOrNonce: 'Invalid code or nonce',
   },
+  INVALID_OIDC_CONFIGURATION: {
+    invalidOIDCConfiguration: 'Invalid OIDC configuration',
+  },
   INVALID_USERINFO_CONFIGURATION: {
     invalidUserinfoConfiguration: 'Invalid userinfo configuration',
   },
@@ -37,6 +40,9 @@ module.exports = {
   },
 
   exits: {
+    invalidOIDCConfiguration: {
+      responseType: 'serverError',
+    },
     invalidCodeOrNonce: {
       responseType: 'unauthorized',
     },
@@ -63,6 +69,7 @@ module.exports = {
         sails.log.warn(`Invalid code or nonce! (IP: ${remoteAddress})`);
         return Errors.INVALID_CODE_OR_NONCE;
       })
+      .intercept('invalidOIDCConfiguration', () => Errors.INVALID_OIDC_CONFIGURATION)
       .intercept('invalidUserinfoConfiguration', () => Errors.INVALID_USERINFO_CONFIGURATION)
       .intercept('emailAlreadyInUse', () => Errors.EMAIL_ALREADY_IN_USE)
       .intercept('usernameAlreadyInUse', () => Errors.USERNAME_ALREADY_IN_USE)

--- a/server/api/controllers/access-tokens/exchange-using-oidc.js
+++ b/server/api/controllers/access-tokens/exchange-using-oidc.js
@@ -3,11 +3,11 @@ const { v4: uuid } = require('uuid');
 const { getRemoteAddress } = require('../../../utils/remoteAddress');
 
 const Errors = {
-  INVALID_CODE_OR_NONCE: {
-    invalidCodeOrNonce: 'Invalid code or nonce',
-  },
   INVALID_OIDC_CONFIGURATION: {
     invalidOIDCConfiguration: 'Invalid OIDC configuration',
+  },
+  INVALID_CODE_OR_NONCE: {
+    invalidCodeOrNonce: 'Invalid code or nonce',
   },
   INVALID_USERINFO_CONFIGURATION: {
     invalidUserinfoConfiguration: 'Invalid userinfo configuration',

--- a/server/api/controllers/show-config.js
+++ b/server/api/controllers/show-config.js
@@ -1,13 +1,13 @@
 const Errors = {
   INVALID_OIDC_CONFIGURATION: {
-    invalidOidcConfiguration: 'Invalid OIDC configuration'
+    invalidOidcConfiguration: 'Invalid OIDC configuration',
   },
 };
 
 module.exports = {
   exits: {
     invalidOidcConfiguration: {
-      responseType: 'serverError'
+      responseType: 'serverError',
     },
   },
 

--- a/server/api/controllers/show-config.js
+++ b/server/api/controllers/show-config.js
@@ -1,8 +1,26 @@
+const Errors = {
+  INVALID_OIDC_CONFIGURATION: {
+    invalidOidcConfiguration: 'Invalid OIDC configuration'
+  },
+};
+
 module.exports = {
-  fn() {
+  exits: {
+    invalidOidcConfiguration: {
+      responseType: 'serverError'
+    },
+  },
+
+  async fn() {
     let oidc = null;
     if (sails.hooks.oidc.isActive()) {
-      const oidcClient = sails.hooks.oidc.getClient();
+      let oidcClient;
+      try {
+        oidcClient = await sails.hooks.oidc.getClient();
+      } catch (error) {
+        sails.log.warn(`Error while initializing OIDC client: ${error}`);
+        throw Errors.INVALID_OIDC_CONFIGURATION;
+      }
 
       const authorizationUrlParams = {
         scope: sails.config.custom.oidcScopes,

--- a/server/api/helpers/users/get-or-create-one-using-oidc.js
+++ b/server/api/helpers/users/get-or-create-one-using-oidc.js
@@ -11,8 +11,8 @@ module.exports = {
   },
 
   exits: {
-    invalidCodeOrNonce: {},
     invalidOIDCConfiguration: {},
+    invalidCodeOrNonce: {},
     invalidUserinfoConfiguration: {},
     missingValues: {},
     emailAlreadyInUse: {},

--- a/server/api/helpers/users/get-or-create-one-using-oidc.js
+++ b/server/api/helpers/users/get-or-create-one-using-oidc.js
@@ -12,6 +12,7 @@ module.exports = {
 
   exits: {
     invalidCodeOrNonce: {},
+    invalidOIDCConfiguration: {},
     invalidUserinfoConfiguration: {},
     missingValues: {},
     emailAlreadyInUse: {},
@@ -19,7 +20,13 @@ module.exports = {
   },
 
   async fn(inputs) {
-    const client = sails.hooks.oidc.getClient();
+    let client;
+    try {
+      client = await sails.hooks.oidc.getClient();
+    } catch (error) {
+      sails.log.warn(`Error while initializing OIDC client: ${error}`);
+      throw 'invalidOIDCConfiguration';
+    }
 
     let tokenSet;
     try {


### PR DESCRIPTION
Sometimes, Planka might boot before the OIDC server is ready to respond. In this case the bootup will freeze with an error:

```
planka-1         |2024-11-18 08:01:14 [E] Failed to lift app: Error: getaddrinfo ENOTFOUND auth.tohka.us
```

In this state the server is not "running", but it also does not exit, leading to a server hang.

Instead, create the client on first OIDC request (lazy loading). If the OIDC client communication fails, the server will still be running but OIDC related requests (login, configuration) will fail with a 500 Internal Server Error and a log explaining the OIDC error:

```
planka-1         |2024-11-18 09:06:39 [W] Error while initializing OIDC client: Error: getaddrinfo ENOTFOUND auth.tohka.us
planka-1         |2024-11-18 09:06:39 [E] Sending 500 ("Server Error") response
```

This ensures that users who are already logged in can continue to use Planka, and the client will be created automatically when the OIDC client starts back up again and a request to use OIDC is sent.