### PR TITLE
fix: apple-touch-icon not found

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Planka is an open source project management software"
     />
-    <link rel="apple-touch-icon" href="logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
## Description

Opening a project page directly by its URL link causes a `404 Not Found` error for the `http://planka/boards/logo192.png` path.
If we open it from the main page, this basic part is already loaded and won't re-render after navigating, but accessing a specific project or card will render the whole HTML, therefore the relative logo192.png path will not be found there.

## Fix

Simply added the `%PUBLIC_URL%` to the link component.