### PR TITLE
fix: quote variables to prevent word splitting

### DIFF
--- a/docker-backup.sh
+++ b/docker-backup.sh
@@ -9,36 +9,36 @@ PLANKA_DOCKER_CONTAINER_PLANKA="planka_planka_1"
 
 # Create Temporary folder
 BACKUP_DATETIME=$(date --utc +%FT%H-%M-%SZ)
-mkdir -p $BACKUP_DATETIME-backup
+mkdir -p "$BACKUP_DATETIME-backup"
 
 # Dump DB into SQL File
 echo -n "Exporting postgres database ... "
-docker exec -t $PLANKA_DOCKER_CONTAINER_POSTGRES pg_dumpall -c -U postgres > $BACKUP_DATETIME-backup/postgres.sql
+docker exec -t "$PLANKA_DOCKER_CONTAINER_POSTGRES" pg_dumpall -c -U postgres > "$BACKUP_DATETIME-backup/postgres.sql"
 echo "Success!"
 
 # Export Docker Voumes
 echo -n "Exporting user-avatars ... "
-docker run --rm --volumes-from $PLANKA_DOCKER_CONTAINER_PLANKA -v $(pwd)/$BACKUP_DATETIME-backup:/backup ubuntu cp -r /app/public/user-avatars /backup/user-avatars
+docker run --rm --volumes-from "$PLANKA_DOCKER_CONTAINER_PLANKA" -v "$(pwd)/$BACKUP_DATETIME-backup:/backup" ubuntu cp -r /app/public/user-avatars /backup/user-avatars
 echo "Success!"
 echo -n "Exporting project-background-images ... "
-docker run --rm --volumes-from $PLANKA_DOCKER_CONTAINER_PLANKA -v $(pwd)/$BACKUP_DATETIME-backup:/backup ubuntu cp -r /app/public/project-background-images /backup/project-background-images
+docker run --rm --volumes-from "$PLANKA_DOCKER_CONTAINER_PLANKA" -v "$(pwd)/$BACKUP_DATETIME-backup:/backup" ubuntu cp -r /app/public/project-background-images /backup/project-background-images
 echo "Success!"
 echo -n "Exporting attachments ... "
-docker run --rm --volumes-from $PLANKA_DOCKER_CONTAINER_PLANKA -v $(pwd)/$BACKUP_DATETIME-backup:/backup ubuntu cp -r /app/private/attachments /backup/attachments
+docker run --rm --volumes-from "$PLANKA_DOCKER_CONTAINER_PLANKA" -v "$(pwd)/$BACKUP_DATETIME-backup:/backup" ubuntu cp -r /app/private/attachments /backup/attachments
 echo "Success!"
 
 # Create tgz
 echo -n "Creating final tarball $BACKUP_DATETIME-backup.tgz ... "
-tar -czf $BACKUP_DATETIME-backup.tgz \
-    $BACKUP_DATETIME-backup/postgres.sql \
-    $BACKUP_DATETIME-backup/user-avatars \
-    $BACKUP_DATETIME-backup/project-background-images \
-    $BACKUP_DATETIME-backup/attachments
+tar -czf "$BACKUP_DATETIME-backup.tgz" \
+    "$BACKUP_DATETIME-backup/postgres.sql" \
+    "$BACKUP_DATETIME-backup/user-avatars" \
+    "$BACKUP_DATETIME-backup/project-background-images" \
+    "$BACKUP_DATETIME-backup/attachments"
 echo "Success!"
 
 #Remove source files
 echo -n "Cleaning up temporary files and folders ... "
-rm -rf $BACKUP_DATETIME-backup
+rm -rf "$BACKUP_DATETIME-backup"
 echo "Success!"
 
 echo "Backup Complete!"

--- a/docker-restore.sh
+++ b/docker-restore.sh
@@ -9,29 +9,29 @@ PLANKA_DOCKER_CONTAINER_PLANKA="planka_planka_1"
 
 # Extract tgz archive
 PLANKA_BACKUP_ARCHIVE_TGZ=$1
-PLANKA_BACKUP_ARCHIVE=$(basename $PLANKA_BACKUP_ARCHIVE_TGZ .tgz)
+PLANKA_BACKUP_ARCHIVE=$(basename "$PLANKA_BACKUP_ARCHIVE_TGZ" .tgz)
 echo -n "Extracting tarball $PLANKA_BACKUP_ARCHIVE_TGZ ... "
-tar -xzf $PLANKA_BACKUP_ARCHIVE_TGZ
+tar -xzf "$PLANKA_BACKUP_ARCHIVE_TGZ"
 echo "Success!"
 
 # Import Database
 echo -n "Importing postgres database ... "
-cat $PLANKA_BACKUP_ARCHIVE/postgres.sql | docker exec -i $PLANKA_DOCKER_CONTAINER_POSTGRES psql -U postgres
+cat "$PLANKA_BACKUP_ARCHIVE/postgres.sql" | docker exec -i "$PLANKA_DOCKER_CONTAINER_POSTGRES" psql -U postgres
 echo "Success!"
 
 # Restore Docker Volumes
 echo -n "Importing user-avatars ... "
-docker run --rm --volumes-from $PLANKA_DOCKER_CONTAINER_PLANKA -v $(pwd)/$PLANKA_BACKUP_ARCHIVE:/backup ubuntu cp -rf /backup/user-avatars /app/public/
+docker run --rm --volumes-from "$PLANKA_DOCKER_CONTAINER_PLANKA" -v "$(pwd)/$PLANKA_BACKUP_ARCHIVE:/backup" ubuntu cp -rf /backup/user-avatars /app/public/
 echo "Success!"
 echo -n "Importing project-background-images ... "
-docker run --rm --volumes-from $PLANKA_DOCKER_CONTAINER_PLANKA -v $(pwd)/$PLANKA_BACKUP_ARCHIVE:/backup ubuntu cp -rf /backup/project-background-images /app/public/
+docker run --rm --volumes-from "$PLANKA_DOCKER_CONTAINER_PLANKA" -v "$(pwd)/$PLANKA_BACKUP_ARCHIVE:/backup" ubuntu cp -rf /backup/project-background-images /app/public/
 echo "Success!"
 echo -n "Importing attachments ... "
-docker run --rm --volumes-from $PLANKA_DOCKER_CONTAINER_PLANKA -v $(pwd)/$PLANKA_BACKUP_ARCHIVE:/backup ubuntu cp -rf /backup/attachments /app/private/
+docker run --rm --volumes-from "$PLANKA_DOCKER_CONTAINER_PLANKA" -v "$(pwd)/$PLANKA_BACKUP_ARCHIVE:/backup" ubuntu cp -rf /backup/attachments /app/private/
 echo "Success!"
 
 echo -n "Cleaning up temporary files and folders ... "
-rm -r $PLANKA_BACKUP_ARCHIVE
+rm -r "$PLANKA_BACKUP_ARCHIVE"
 echo "Success!"
 
 echo "Restore complete!"


### PR DESCRIPTION
`docker-backup.sh` and `docker-restore.sh` didn't quote variables, which prevented them from running in certain environments. This PR adds consistent quotation for all variables in those scripts.

Ref.: https://www.shellcheck.net/wiki/SC2046 https://www.shellcheck.net/wiki/SC2086