### PR TITLE
build: 🐛 don't use explicit latest npm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as server-dependencies
+FROM node:18-alpine AS server-dependencies
 
 RUN apk -U upgrade \
   && apk add build-base python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY server/package.json server/package-lock.json ./
 
-RUN npm install npm@latest --global \
+RUN npm install npm --global \
   && npm install pnpm --global \
   && pnpm import \
   && pnpm install --prod
@@ -19,7 +19,7 @@ WORKDIR /app
 
 COPY client/package.json client/package-lock.json ./
 
-RUN npm install npm@latest --global \
+RUN npm install npm --global \
   && npm install pnpm --global \
   && pnpm import \
   && pnpm install --prod

--- a/config/development/Dockerfile.client
+++ b/config/development/Dockerfile.client
@@ -1,4 +1,4 @@
-FROM node:18-alpine as server-dependencies
+FROM node:18-alpine AS server-dependencies
 
 RUN apk -U upgrade \
   && apk add build-base python3 \

--- a/config/development/Dockerfile.client
+++ b/config/development/Dockerfile.client
@@ -6,7 +6,7 @@ RUN apk -U upgrade \
 
 WORKDIR /app/client
 COPY package.json package-lock.json /app/client/
-RUN npm install npm@latest --global \
+RUN npm install npm --global \
   && npm install pnpm --global \
   && pnpm import \
   && pnpm install

--- a/config/development/Dockerfile.server
+++ b/config/development/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM node:18-alpine as server-dependencies
+FROM node:18-alpine AS server-dependencies
 
 RUN apk -U upgrade \
   && apk add build-base python3 \

--- a/config/development/Dockerfile.server
+++ b/config/development/Dockerfile.server
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 
-RUN npm install npm@latest --global \
+RUN npm install npm --global \
   && npm install pnpm --global \
   && pnpm import \
   && pnpm install


### PR DESCRIPTION
- Prevent mismatch of node and npm by removing `@latest` tag. `0.737 npm error engine Not compatible with your version of node/npm: npm@11.0.0`
- Fixes casing warnings on docker build ` => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)`