### PR TITLE
feat: ✨ added button to delete all pending notifications

### DIFF
--- a/client/src/components/Header/NotificationsStep.jsx
+++ b/client/src/components/Header/NotificationsStep.jsx
@@ -22,6 +22,12 @@ const NotificationsStep = React.memo(({ items, onDelete, onClose }) => {
     [onDelete],
   );
 
+  const handleDeleteAll = useCallback(() => {
+    items.forEach((item) => {
+      onDelete(item.id);
+    });
+  }, [items, onDelete]);
+
   const renderItemContent = useCallback(
     ({ activity, card }) => {
       switch (activity.type) {
@@ -85,6 +91,15 @@ const NotificationsStep = React.memo(({ items, onDelete, onClose }) => {
       <Popup.Content>
         {items.length > 0 ? (
           <div className={styles.wrapper}>
+            {items.length > 1 && (
+              <Button
+                type="button"
+                icon="trash alternate outline"
+                content={t('action.deleteNotifications')}
+                onClick={handleDeleteAll}
+                className={styles.deleteAllButton}
+              />
+            )}
             {items.map((item) => (
               <div key={item.id} className={styles.item}>
                 {item.card && item.activity ? (

--- a/client/src/components/Header/NotificationsStep.module.scss
+++ b/client/src/components/Header/NotificationsStep.module.scss
@@ -62,4 +62,19 @@
       border-radius: 3px;
     }
   }
+
+  .deleteAllButton {
+    background: transparent;
+    box-shadow: none;
+    transition: background 0.3s ease;
+
+    display: block;
+    margin: 0 auto;
+    padding: 0.5em 1em;
+    font-size: 0.875em;
+
+    &:hover {
+      background: #e9e9e9;
+    }
+  }
 }

--- a/client/src/locales/ar-YE/core.js
+++ b/client/src/locales/ar-YE/core.js
@@ -204,6 +204,7 @@ export default {
       deleteLabel: 'حذف الملصق',
       deleteList: 'حذف القائمة',
       deleteList_title: 'حذف القائمة',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'حذف المشروع',
       deleteProject_title: 'حذف المشروع',
       deleteTask: 'حذف المهمة',

--- a/client/src/locales/bg-BG/core.js
+++ b/client/src/locales/bg-BG/core.js
@@ -204,6 +204,7 @@ export default {
       deleteLabel: 'Изтриване на етикета',
       deleteList: 'Изтриване на списък',
       deleteList_title: 'Изтриване на списък',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Изтриване на проект',
       deleteProject_title: 'Изтриване на проект',
       deleteTask: 'Изтриване на задача',

--- a/client/src/locales/cs-CZ/core.js
+++ b/client/src/locales/cs-CZ/core.js
@@ -201,6 +201,7 @@ export default {
       deleteLabel: 'Smazat štítek',
       deleteList: 'Smazat seznam',
       deleteList_title: 'Smazat seznam',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Smazat projekt',
       deleteProject_title: 'Smazat projekt',
       deleteTask: 'Smazat úkol',

--- a/client/src/locales/da-DK/core.js
+++ b/client/src/locales/da-DK/core.js
@@ -175,6 +175,7 @@ export default {
       deleteLabel: 'Slet mærkat',
       deleteList: 'Slet liste',
       deleteList_title: 'Slet liste',
+      deleteNotifications: 'Slet notifikationer',
       deleteProject: 'Slet projekt',
       deleteProject_title: 'Slet projekt',
       deleteTask: 'Slet opgave',

--- a/client/src/locales/de-DE/core.js
+++ b/client/src/locales/de-DE/core.js
@@ -187,6 +187,7 @@ export default {
       deleteLabel: 'Label löschen',
       deleteList: 'Liste löschen',
       deleteList_title: 'Liste löschen',
+      deleteNotifications: 'Benachrichtigungen löschen',
       deleteProject: 'Projekt löschen',
       deleteProject_title: 'Projekt löschen',
       deleteTask: 'Aufgabe löschen',

--- a/client/src/locales/en-GB/core.js
+++ b/client/src/locales/en-GB/core.js
@@ -205,6 +205,7 @@ export default {
       deleteLabel: 'Delete label',
       deleteList: 'Delete list',
       deleteList_title: 'Delete List',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Delete project',
       deleteProject_title: 'Delete Project',
       deleteTask: 'Delete task',

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -201,6 +201,7 @@ export default {
       deleteLabel: 'Delete label',
       deleteList: 'Delete list',
       deleteList_title: 'Delete List',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Delete project',
       deleteProject_title: 'Delete Project',
       deleteTask: 'Delete task',

--- a/client/src/locales/es-ES/core.js
+++ b/client/src/locales/es-ES/core.js
@@ -164,6 +164,7 @@ export default {
       deleteLabel: 'Borrar etiqueta',
       deleteList: 'Borrar lista',
       deleteList_title: 'Borrar Lista',
+      deleteNotifications: 'Borrar notificaciones',
       deleteProject: 'Borrar proyecto',
       deleteProject_title: 'Borrar Proyecto',
       deleteTask: 'Borrar tarea',

--- a/client/src/locales/fa-IR/core.js
+++ b/client/src/locales/fa-IR/core.js
@@ -206,6 +206,7 @@ export default {
       deleteLabel: 'حذف برچسب',
       deleteList: 'حذف لیست',
       deleteList_title: 'حذف لیست',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'حذف پروژه',
       deleteProject_title: 'حذف پروژه',
       deleteTask: 'حذف وظیفه',

--- a/client/src/locales/fr-FR/core.js
+++ b/client/src/locales/fr-FR/core.js
@@ -207,6 +207,7 @@ export default {
       deleteLabel: "Supprimer l'étiquette",
       deleteList: 'Supprimer la liste',
       deleteList_title: 'Supprimer la liste',
+      deleteNotifications: 'Supprimer les notifications',
       deleteProject: 'Supprimer le projet',
       deleteProject_title: 'Supprimer le projet',
       deleteTask: 'Supprimer la tâche',

--- a/client/src/locales/hu-HU/core.js
+++ b/client/src/locales/hu-HU/core.js
@@ -206,6 +206,7 @@ export default {
       deleteLabel: 'Címke törlése',
       deleteList: 'Lista törlése',
       deleteList_title: 'Lista törlése',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Projekt törlése',
       deleteProject_title: 'Projekt törlése',
       deleteTask: 'Feladat törlése',

--- a/client/src/locales/id-ID/core.js
+++ b/client/src/locales/id-ID/core.js
@@ -196,6 +196,7 @@ export default {
       deleteLabel: 'Hapus labek',
       deleteList: 'Hapus daftar',
       deleteList_title: 'Hapus Daftar',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Hapus proyek',
       deleteProject_title: 'Hapus Proyek',
       deleteTask: 'Hapus tugas',

--- a/client/src/locales/it-IT/core.js
+++ b/client/src/locales/it-IT/core.js
@@ -200,6 +200,7 @@ export default {
       deleteLabel: 'Elimina etichetta',
       deleteList: 'Elimina lista',
       deleteList_title: 'Elimina Lista',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Elimina progetto',
       deleteProject_title: 'Elimina Progetto',
       deleteTask: 'Elimina task',

--- a/client/src/locales/ja-JP/core.js
+++ b/client/src/locales/ja-JP/core.js
@@ -196,6 +196,7 @@ export default {
       deleteLabel: 'ラベルを削除',
       deleteList: 'リストを削除',
       deleteList_title: 'リストを削除',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'プロジェクトを削除',
       deleteProject_title: 'プロジェクトを削除',
       deleteTask: 'タスクを削除',

--- a/client/src/locales/ko-KR/core.js
+++ b/client/src/locales/ko-KR/core.js
@@ -195,6 +195,7 @@ export default {
       deleteLabel: '라벨 삭제',
       deleteList: '목록 삭제',
       deleteList_title: '목록 삭제',
+      deleteNotifications: 'Dismiss all',
       deleteProject: '프로젝트 삭제',
       deleteProject_title: '프로젝트 삭제',
       deleteTask: '업무 삭제',

--- a/client/src/locales/nl-NL/core.js
+++ b/client/src/locales/nl-NL/core.js
@@ -197,6 +197,7 @@ export default {
       deleteLabel: 'Label verwijderen',
       deleteList: 'Lijst verwijderen',
       deleteList_title: 'Lijst verwijderen',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Project verwijderen',
       deleteProject_title: 'Project verwijderen',
       deleteTask: 'Taak verwijderen',

--- a/client/src/locales/pl-PL/core.js
+++ b/client/src/locales/pl-PL/core.js
@@ -203,6 +203,7 @@ export default {
       deleteLabel: 'Usuń oznaczenie',
       deleteList: 'Usuń listę',
       deleteList_title: 'Usuń Listę',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Usuń projekt',
       deleteProject_title: 'Usuń Projekt',
       deleteTask: 'Usuń zadanie',

--- a/client/src/locales/pt-BR/core.js
+++ b/client/src/locales/pt-BR/core.js
@@ -196,6 +196,7 @@ export default {
       deleteLabel: 'Excluir rótulo',
       deleteList: 'Excluir lista',
       deleteList_title: 'Excluir Lista',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Excluir projeto',
       deleteProject_title: 'Excluir Projeto',
       deleteTask: 'Excluir tarefa',

--- a/client/src/locales/ro-RO/core.js
+++ b/client/src/locales/ro-RO/core.js
@@ -197,6 +197,7 @@ export default {
       deleteLabel: 'Ștergeți Eticheta',
       deleteList: 'Ștergeți lista',
       deleteList_title: 'Ștergeți Lista',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Ștergeți proiectul',
       deleteProject_title: 'Ștergeți Proiectul',
       deleteTask: 'Ștergeți sarcina',

--- a/client/src/locales/ru-RU/core.js
+++ b/client/src/locales/ru-RU/core.js
@@ -206,6 +206,7 @@ export default {
       deleteLabel: 'Удалить метку',
       deleteList: 'Удалить список',
       deleteList_title: 'Удалить список',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Удалить проект',
       deleteProject_title: 'Удалить проект',
       deleteTask: 'Удалить задачу',

--- a/client/src/locales/sk-SK/core.js
+++ b/client/src/locales/sk-SK/core.js
@@ -176,6 +176,7 @@ export default {
       deleteLabel: 'Zmazať štítok',
       deleteList: 'Zmazať zoznam',
       deleteList_title: 'Zmazať zoznam',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Zmazať projekt',
       deleteProject_title: 'Zmazať projekt',
       deleteTask: 'Zmazať úlohu',

--- a/client/src/locales/sr-Cyrl-CS/core.js
+++ b/client/src/locales/sr-Cyrl-CS/core.js
@@ -205,6 +205,7 @@ export default {
       deleteLabel: 'Обриши ознаку',
       deleteList: 'Обриши списак',
       deleteList_title: 'Обриши списак',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Обриши пројекат',
       deleteProject_title: 'Обриши пројекат',
       deleteTask: 'Обриши задатак',

--- a/client/src/locales/sr-Latn-CS/core.js
+++ b/client/src/locales/sr-Latn-CS/core.js
@@ -205,6 +205,7 @@ export default {
       deleteLabel: 'Obriši oznaku',
       deleteList: 'Obriši spisak',
       deleteList_title: 'Obriši spisak',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Obriši projekat',
       deleteProject_title: 'Obriši projekat',
       deleteTask: 'Obriši zadatak',

--- a/client/src/locales/sv-SE/core.js
+++ b/client/src/locales/sv-SE/core.js
@@ -178,6 +178,7 @@ export default {
       deleteLabel: 'Ta bort etikett',
       deleteList: 'Ta bort lista',
       deleteList_title: 'Ta Bort Lista',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Ta bort projekt',
       deleteProject_title: 'Ta Bort Projekt',
       deleteTask: 'Ta bort uppgift',

--- a/client/src/locales/tr-TR/core.js
+++ b/client/src/locales/tr-TR/core.js
@@ -179,6 +179,7 @@ export default {
       deleteLabel: 'Etiketi sil',
       deleteList: 'Listeyi sil',
       deleteList_title: 'Listeyi Sil',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Projeyi sil',
       deleteProject_title: 'Projeyi Sil',
       deleteTask: 'Görevi sil',

--- a/client/src/locales/uk-UA/core.js
+++ b/client/src/locales/uk-UA/core.js
@@ -196,6 +196,7 @@ export default {
       deleteLabel: 'Видалити мітку',
       deleteList: 'Видалити список',
       deleteList_title: 'Видалити Список',
+      deleteNotifications: 'Dismiss all',
       deleteProject: 'Видалити проект',
       deleteProject_title: 'Видалити Проект',
       deleteTask: 'Видалити завдання',

--- a/client/src/locales/uz-UZ/core.js
+++ b/client/src/locales/uz-UZ/core.js
@@ -175,6 +175,7 @@ export default {
       deleteLabel: "Yorliqni o'chirish",
       deleteList: "Ro'yxatni o'chirish",
       deleteList_title: "Ro'yxatni O'chirish",
+      deleteNotifications: 'Dismiss all',
       deleteProject: "Loyihani o'chirish",
       deleteProject_title: "Loyihani O'chirish",
       deleteTask: "Vazifani o'chirish",

--- a/client/src/locales/zh-CN/core.js
+++ b/client/src/locales/zh-CN/core.js
@@ -192,6 +192,7 @@ export default {
       deleteLabel: '删除标签',
       deleteList: '删除列表',
       deleteList_title: '删除列表',
+      deleteNotifications: 'Dismiss all',
       deleteProject: '删除项目',
       deleteProject_title: '删除项目',
       deleteTask: '删除任务',

--- a/client/src/locales/zh-TW/core.js
+++ b/client/src/locales/zh-TW/core.js
@@ -192,6 +192,7 @@ export default {
       deleteLabel: '刪除標籤',
       deleteList: '刪除列表',
       deleteList_title: '刪除列表',
+      deleteNotifications: 'Dismiss all',
       deleteProject: '刪除專案',
       deleteProject_title: '刪除專案',
       deleteTask: '刪除任務',


### PR DESCRIPTION
New button to delete all pending notifications at once. Button is only visible if there are more than one notification.

## No notifications

![Screenshot 2025-01-15 at 09 10 58](https://github.com/user-attachments/assets/53eea8cd-98e6-411f-a268-31d4d2d231a0)

## One notification

![Screenshot 2025-01-15 at 09 11 33](https://github.com/user-attachments/assets/bf590971-ea78-4af4-a084-318de229f681)

## Two notifications

![Screenshot 2025-01-15 at 09 11 51](https://github.com/user-attachments/assets/c692db99-2797-4073-8172-5ae5da74eef2)

## Two notifications - Hover

![Screenshot 2025-01-15 at 09 11 55](https://github.com/user-attachments/assets/df000462-b7ec-4559-bd5f-04df96d338e0)


