### PR TITLE
[FIX] configurable db schema name

### DIFF
--- a/server/config/datastores.js
+++ b/server/config/datastores.js
@@ -48,6 +48,6 @@ module.exports.datastores = {
 
     adapter: 'sails-postgresql',
     url: process.env.DATABASE_URL,
-    schemaName: process.env.DB_SCHEMA || 'public',
+    schemaName: process.env.DATABASE_SCHEMA || 'public',
   },
 };

--- a/server/config/datastores.js
+++ b/server/config/datastores.js
@@ -48,5 +48,6 @@ module.exports.datastores = {
 
     adapter: 'sails-postgresql',
     url: process.env.DATABASE_URL,
+    schemaName: process.env.DB_SCHEMA || 'public',
   },
 };

--- a/server/config/datastores.js
+++ b/server/config/datastores.js
@@ -48,6 +48,6 @@ module.exports.datastores = {
 
     adapter: 'sails-postgresql',
     url: process.env.DATABASE_URL,
-    schemaName: process.env.DATABASE_SCHEMA || 'public',
+    schemaName: process.env.DATABASE_SCHEMA,
   },
 };


### PR DESCRIPTION
By default sails-postgres was using `public` even though default `search_path` of db user was different. 
Source: https://stackoverflow.com/a/57210065
Did not face this same issue with Knex migrations