### PR TITLE
feat: Support loading passwords from docker secrets

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -21,22 +21,27 @@ services:
       # - TOKEN_EXPIRES_IN=365 # In days
 
       # related: https://github.com/knex/knex/issues/2354
-      # As knex does not pass query parameters from the connection string we
-      # have to use environment variables in order to pass the desired values, e.g.
+      # As knex does not pass query parameters from the connection string,
+      # we have to use environment variables in order to pass the desired values, e.g.
       # - PGSSLMODE=<value>
 
       # Configure knex to accept SSL certificates
       # - KNEX_REJECT_UNAUTHORIZED_SSL_CERTIFICATE=false
 
-      # - DEFAULT_LANGUAGE=en-US # Used for per-board notifications
+      # Used for per-board notifications
+      # - DEFAULT_LANGUAGE=en-US
 
-      # - DEFAULT_ADMIN_EMAIL=demo@demo.demo # Do not remove if you want to prevent this user from being edited/deleted
+      # Do not comment out DEFAULT_ADMIN_EMAIL if you want to prevent this user from being edited/deleted
+      # - DEFAULT_ADMIN_EMAIL=demo@demo.demo
       # - DEFAULT_ADMIN_PASSWORD=demo
       # - DEFAULT_ADMIN_NAME=Demo Demo
       # - DEFAULT_ADMIN_USERNAME=demo
 
       # - ACTIVE_USERS_LIMIT=
-      # - SHOW_DETAILED_AUTH_ERRORS=false # Set to true to show more detailed authentication error messages. It should not be enabled without a rate limiter for security reasons.
+
+      # Set to true to show more detailed authentication error messages.
+      # It should not be enabled without a rate limiter for security reasons.
+      # - SHOW_DETAILED_AUTH_ERRORS=false
 
       # - S3_ENDPOINT=
       # - S3_REGION=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,15 @@ services:
     environment:
       - BASE_URL=http://localhost:3000
       - DATABASE_URL=postgresql://postgres@postgres/planka
+      # Optionally store the database password in secrets:
+      # - DATABASE_URL=postgresql://postgres:$${DATABASE_PASSWORD}@postgres/planka
+      # - DATABASE_PASSWORD__FILE=/run/secrets/planka_database_password
+      # ... and add the following to the service:
+      #   secrets:
+      #    - planka_database_password
+
       - SECRET_KEY=notsecretkey
+      # If not set, it is loaded from the file SECRET_KEY__FILE on start.
 
       # - LOG_LEVEL=warn
 
@@ -69,6 +77,7 @@ services:
       # - SMTP_SECURE=true
       # - SMTP_USER=
       # - SMTP_PASSWORD=
+      # If not set, SMTP_PASSWORD is loaded from the file SMTP_PASSWORD__FILE on start.
       # - SMTP_FROM="Demo Demo" <demo@demo.demo>
       # - SMTP_TLS_REJECT_UNAUTHORIZED=false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,15 +12,17 @@ services:
     environment:
       - BASE_URL=http://localhost:3000
       - DATABASE_URL=postgresql://postgres@postgres/planka
+
       # Optionally store the database password in secrets:
       # - DATABASE_URL=postgresql://postgres:$${DATABASE_PASSWORD}@postgres/planka
-      # - DATABASE_PASSWORD__FILE=/run/secrets/planka_database_password
-      # ... and add the following to the service:
-      #   secrets:
-      #    - planka_database_password
+      # - DATABASE_PASSWORD__FILE=/run/secrets/database_password
+      # And add the following to the service:
+      # secrets:
+      #   - database_password
 
       - SECRET_KEY=notsecretkey
-      # If not set, it is loaded from the file SECRET_KEY__FILE on start.
+      # Optionally store in secrets - then SECRET_KEY should not be set
+      # - SECRET_KEY__FILE=/run/secrets/secret_key
 
       # - LOG_LEVEL=warn
 
@@ -28,33 +30,44 @@ services:
       # - TOKEN_EXPIRES_IN=365 # In days
 
       # related: https://github.com/knex/knex/issues/2354
-      # As knex does not pass query parameters from the connection string we
-      # have to use environment variables in order to pass the desired values, e.g.
+      # As knex does not pass query parameters from the connection string,
+      # we have to use environment variables in order to pass the desired values, e.g.
       # - PGSSLMODE=<value>
 
       # Configure knex to accept SSL certificates
       # - KNEX_REJECT_UNAUTHORIZED_SSL_CERTIFICATE=false
 
-      # - DEFAULT_LANGUAGE=en-US # Used for per-board notifications
+      # Used for per-board notifications
+      # - DEFAULT_LANGUAGE=en-US
 
-      # - DEFAULT_ADMIN_EMAIL=demo@demo.demo # Do not remove if you want to prevent this user from being edited/deleted
+      # Do not comment out DEFAULT_ADMIN_EMAIL if you want to prevent this user from being edited/deleted
+      # - DEFAULT_ADMIN_EMAIL=demo@demo.demo
       # - DEFAULT_ADMIN_PASSWORD=demo
+      # Optionally store in secrets - then DEFAULT_ADMIN_PASSWORD should not be set
+      # - DEFAULT_ADMIN_PASSWORD__FILE=/run/secrets/default_admin_password
       # - DEFAULT_ADMIN_NAME=Demo Demo
       # - DEFAULT_ADMIN_USERNAME=demo
 
       # - ACTIVE_USERS_LIMIT=
-      # - SHOW_DETAILED_AUTH_ERRORS=false # Set to true to show more detailed authentication error messages. It should not be enabled without a rate limiter for security reasons.
+
+      # Set to true to show more detailed authentication error messages.
+      # It should not be enabled without a rate limiter for security reasons.
+      # - SHOW_DETAILED_AUTH_ERRORS=false
 
       # - S3_ENDPOINT=
       # - S3_REGION=
       # - S3_ACCESS_KEY_ID=
       # - S3_SECRET_ACCESS_KEY=
+      # Optionally store in secrets - then S3_SECRET_ACCESS_KEY should not be set
+      # - S3_SECRET_ACCESS_KEY__FILE=/run/secrets/s3_secret_access_key
       # - S3_BUCKET=
       # - S3_FORCE_PATH_STYLE=true
 
       # - OIDC_ISSUER=
       # - OIDC_CLIENT_ID=
       # - OIDC_CLIENT_SECRET=
+      # Optionally store in secrets - then OIDC_CLIENT_SECRET should not be set
+      # - OIDC_CLIENT_SECRET__FILE=/run/secrets/oidc_client_secret
       # - OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG=
       # - OIDC_USERINFO_SIGNED_RESPONSE_ALG=
       # - OIDC_SCOPES=openid email profile
@@ -77,7 +90,8 @@ services:
       # - SMTP_SECURE=true
       # - SMTP_USER=
       # - SMTP_PASSWORD=
-      # If not set, SMTP_PASSWORD is loaded from the file SMTP_PASSWORD__FILE on start.
+      # Optionally store in secrets - then SMTP_PASSWORD should not be set
+      # - SMTP_PASSWORD__FILE=/run/secrets/smtp_password
       # - SMTP_FROM="Demo Demo" <demo@demo.demo>
       # - SMTP_TLS_REJECT_UNAUTHORIZED=false
 

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -13,22 +13,27 @@ SECRET_KEY=notsecretkey
 # TOKEN_EXPIRES_IN=365 # In days
 
 # related: https://github.com/knex/knex/issues/2354
-# As knex does not pass query parameters from the connection string we
-# have to use environment variables in order to pass the desired values, e.g.
+# As knex does not pass query parameters from the connection string,
+# we have to use environment variables in order to pass the desired values, e.g.
 # PGSSLMODE=<value>
 
 # Configure knex to accept SSL certificates
 # KNEX_REJECT_UNAUTHORIZED_SSL_CERTIFICATE=false
 
-# DEFAULT_LANGUAGE=en-US # Used for per-board notifications
+# Used for per-board notifications
+# DEFAULT_LANGUAGE=en-US
 
-# DEFAULT_ADMIN_EMAIL=demo@demo.demo # Do not remove if you want to prevent this user from being edited/deleted
+# Do not comment out DEFAULT_ADMIN_EMAIL if you want to prevent this user from being edited/deleted
+# DEFAULT_ADMIN_EMAIL=demo@demo.demo
 # DEFAULT_ADMIN_PASSWORD=demo
 # DEFAULT_ADMIN_NAME=Demo Demo
 # DEFAULT_ADMIN_USERNAME=demo
 
 # ACTIVE_USERS_LIMIT=
-# SHOW_DETAILED_AUTH_ERRORS=false # Set to true to show more detailed authentication error messages. It should not be enabled without a rate limiter for security reasons.
+
+# Set to true to show more detailed authentication error messages.
+# It should not be enabled without a rate limiter for security reasons.
+# SHOW_DETAILED_AUTH_ERRORS=false
 
 # S3_ENDPOINT=
 # S3_REGION=

--- a/server/start.sh
+++ b/server/start.sh
@@ -1,2 +1,28 @@
 #!/bin/bash
-export NODE_ENV=production && set -e && node db/init.js && node app.js --prod
+
+set -eu
+
+# Load secrets from files if needed. Only the first line, not including the \n,
+# is loaded.
+if [[ -z "${SECRET_KEY:-}" && -e "${SECRET_KEY__FILE:-}" ]]; then
+  read SECRET_KEY <"${SECRET_KEY__FILE}"
+  export SECRET_KEY
+fi
+if [[ -z "${SMTP_PASSWORD:-}" && -e "${SMTP_PASSWORD__FILE:-}" ]]; then
+  read SMTP_PASSWORD <"${SMTP_PASSWORD__FILE}"
+  export SMTP_PASSWORD
+fi
+if [[ -z "${DATABASE_PASSWORD:-}" && -e "${DATABASE_PASSWORD__FILE:-}" ]]; then
+  read DATABASE_PASSWORD <"${DATABASE_PASSWORD__FILE}"
+  # No need to export DATABASE_PASSWORD, it is only used below.
+fi
+# Replace the exact "${DATABASE_PASSWORD}" string in the DATABASE_URL
+# environment variable with the contents of DATABASE_PASSWORD.
+if [[ -n "${DATABASE_PASSWORD:-}" && -n "${DATABASE_URL}" ]]; then
+  export DATABASE_URL="${DATABASE_URL/\$\{DATABASE_PASSWORD\}/${DATABASE_PASSWORD}}"
+fi
+
+export NODE_ENV=production
+
+node db/init.js
+exec node app.js --prod


### PR DESCRIPTION
Docker secrets are exposed as files in `/run/secrets/` inside the container instead of as environment variables. To support deployments where the passwords are stored in secrets, this patch adds support for loading the `SMTP_PASSWORD`, `SECRET_KEY` and the database password from files, using the `__FILE` suffix convention found in many docker images.

The database password is part of the `DATABASE_URL` environment variable, if a password is used at all. To support injecting the password into the DATABASE_URL without having to use the whole URL as the secret, the `start.sh` replaces the string `${DATABASE_PASSWORD}` in the `DATABASE_URL` environment variable by the contents of the `DATABASE_PASSWORD` variable, which can now also be loaded from the corresponding file passed in `DATABASE_PASSWORD__FILE`.

These changes are backwards compatible since they only load the `__FILE` suffix version if the original variable was not set the `__FILE` one is set.

Added comments in docker-compose.yml with examples for discoverability of the feature. Tested this on top of 2.0.0-rc.2.