### PR TITLE
build: :technologist: specify nodemon and remove USER directive for dev container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,7 @@
-FROM node:18-alpine
+FROM node:lts-alpine
 
 RUN apk -U upgrade \
   && apk add bash build-base python3 xdg-utils --no-cache \
   && npm install npm --global
 
-USER node
 WORKDIR /app

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -112,7 +112,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "pg_isready -U postgres -d planka && psql -U postgres -d planka -c 'SELECT 1'",
+          "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-planka} && psql -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-planka} -c 'SELECT 1'",
         ]
       interval: 3s
       timeout: 5s

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,6 +1,7 @@
 services:
   planka-server:
     build:
+      context: .
       dockerfile: Dockerfile.dev
     image: planka-dev
     pull_policy: never

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,6 @@
 services:
   planka-server:
     build:
-      context: .
       dockerfile: Dockerfile.dev
     image: planka-dev
     pull_policy: never
@@ -109,10 +108,15 @@ services:
       - POSTGRES_DB=planka
       - POSTGRES_HOST_AUTH_METHOD=trust
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d planka"]
-      interval: 10s
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U postgres -d planka && psql -U postgres -d planka -c 'SELECT 1'",
+        ]
+      interval: 3s
       timeout: 5s
-      retries: 5
+      retries: 15
+      start_period: 10s
 
 volumes:
   db-data:

--- a/server/nodemon.json
+++ b/server/nodemon.json
@@ -1,0 +1,15 @@
+{
+  "watch": [
+    "api/**/*.js",
+    "config/**/*.js",
+    "db/**/*.js",
+    "utils/**/*.js",
+    "app.js",
+    "constants.js"
+  ],
+  "ignore": ["node_modules", ".tmp", ".venv"],
+  "ext": "js,json",
+  "verbose": true,
+  "delay": 1000,
+  "legacyWatch": false
+}


### PR DESCRIPTION
* Updated the base image in `Dockerfile.dev` from `node:18-alpine` to `node:lts-alpine` to use more or less the same as for production docker build (where the client is build lts and server is 18... so yeah not really...)
* Removed the `USER node` directive, to prevent permission issues as we hook the whole folder into the container.
* Modified the `docker-compose-dev.yml` file to enhance the database healthcheck. The new healthcheck ensures not only postgres is ready but also the database is ready by running a sample query (`SELECT 1`) and adjusts the interval, retries, and start period for better reliability.
* Added a `nodemon.json` configuration file to watch only relevant files (node_modules would be ignored but not files like the python venv) and avoid rapid successive restarts with the delay.