### PR TITLE
fix: Improve dev setup

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,6 +12,7 @@ services:
     ports:
       - 1337:1337
     environment:
+      - BASE_URL=http://localhost:1337
       - DATABASE_URL=postgresql://postgres@postgres/planka
       - SECRET_KEY=notsecretkey
 

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -24,10 +24,10 @@ SECRET_KEY=notsecretkey
 # DEFAULT_LANGUAGE=en-US
 
 # Do not comment out DEFAULT_ADMIN_EMAIL if you want to prevent this user from being edited/deleted
-# DEFAULT_ADMIN_EMAIL=demo@demo.demo
-# DEFAULT_ADMIN_PASSWORD=demo
-# DEFAULT_ADMIN_NAME=Demo Demo
-# DEFAULT_ADMIN_USERNAME=demo
+DEFAULT_ADMIN_EMAIL=demo@demo.demo
+DEFAULT_ADMIN_PASSWORD=demo
+DEFAULT_ADMIN_NAME=Demo Demo
+DEFAULT_ADMIN_USERNAME=demo
 
 # ACTIVE_USERS_LIMIT=
 

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -24,10 +24,10 @@ SECRET_KEY=notsecretkey
 # DEFAULT_LANGUAGE=en-US
 
 # Do not comment out DEFAULT_ADMIN_EMAIL if you want to prevent this user from being edited/deleted
-DEFAULT_ADMIN_EMAIL=demo@demo.demo
-DEFAULT_ADMIN_PASSWORD=demo
-DEFAULT_ADMIN_NAME=Demo Demo
-DEFAULT_ADMIN_USERNAME=demo
+# DEFAULT_ADMIN_EMAIL=demo@demo.demo
+# DEFAULT_ADMIN_PASSWORD=demo
+# DEFAULT_ADMIN_NAME=Demo Demo
+# DEFAULT_ADMIN_USERNAME=demo
 
 # ACTIVE_USERS_LIMIT=
 


### PR DESCRIPTION
- Add BASE_URL to docker-compose-dev so the first run does not fail if someone's forgotten to copy .env