### PR TITLE
Add tmpfs to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
       - background-images:/app/public/background-images
       - attachments:/app/private/attachments
     # Optionally override this to your user/group
-    #user: "1000:1000"
-    #tmpfs:
-    #  - /app/.tmp:mode=770,uid=1000,gid=1000
+    # user: 1000:1000
+    # tmpfs:
+    #   - /app/.tmp:mode=770,uid=1000,gid=1000
     ports:
       - 3000:1337
     environment:


### PR DESCRIPTION
Based on the findings from https://github.com/plankanban/planka/issues/852 a tmpfs location is needed for /app/.tmp to send attachments _if_ you override the user UID/GID.

All of my volume mounts point to a local directory for a system user so I have to override the uid/gid for all of my containers. I believe many others fit into this same scenario, so having this optional text in the docker compose file would be very helpful.

I would have discussed within the issue before submitting this PR but the issue was already closed. I hope you receive this well!