### PR TITLE
Danish translation small fix

### DIFF
--- a/client/src/locales/da-DK/core.js
+++ b/client/src/locales/da-DK/core.js
@@ -118,7 +118,7 @@ export default {
       contentExceedsLimit: 'Indhold overskrider {{limit}}',
       contentOfThisAttachmentIsTooBigToDisplay:
         'Indholdet af denne vedhæftning er for stort til at blive vist.',
-      copy_inline: 'kopier',
+      copy_inline: 'kopi',
       createBoard_title: 'Opret tavle',
       createCustomFieldGroup_title: 'Opret brugerdefineret feltgruppe',
       createLabel_title: 'Opret label',


### PR DESCRIPTION
Corrected a word from plural to singular, and now it fits the context.