### PR TITLE
feat(api): allow setting custom fields when creating a card via API (closes #1155)

### DIFF
--- a/server/api/controllers/cards/create.js
+++ b/server/api/controllers/cards/create.js
@@ -53,6 +53,9 @@ module.exports = {
       type: 'json',
       custom: isStopwatch,
     },
+    customFields: {
+      type: 'ref',
+    },
   },
 
   exits: {
@@ -95,6 +98,10 @@ module.exports = {
       'dueDate',
       'stopwatch',
     ]);
+
+    if (inputs.customFields) {
+      values.customFields = inputs.customFields;
+    }
 
     const card = await sails.helpers.cards.createOne
       .with({

--- a/server/api/helpers/cards/create-one.js
+++ b/server/api/helpers/cards/create-one.js
@@ -75,6 +75,33 @@ module.exports = {
       listChangedAt: new Date().toISOString(),
     });
 
+    if (values.customFields) {
+      const customFieldGroups = await CustomFieldGroup.qm.getByBoardId(values.board.id);
+      const customFieldGroupMap = _.keyBy(customFieldGroups, 'name');
+      const customFieldGroupIds = customFieldGroups.map((g) => g.id);
+      const customFields = await CustomField.qm.getByCustomFieldGroupIds(customFieldGroupIds);
+      const customFieldMap = _.keyBy(customFields, (f) => `${f.customFieldGroupId}:${f.name}`);
+
+      const createValuePromises = [];
+      Object.entries(values.customFields).forEach(([groupName, fields]) => {
+        const group = customFieldGroupMap[groupName];
+        if (!group) return;
+        Object.entries(fields).forEach(([fieldName, content]) => {
+          const field = customFieldMap[`${group.id}:${fieldName}`];
+          if (!field) return;
+          createValuePromises.push(
+            CustomFieldValue.create({
+              cardId: card.id,
+              customFieldGroupId: group.id,
+              customFieldId: field.id,
+              content: String(content),
+            }),
+          );
+        });
+      });
+      await Promise.all(createValuePromises);
+    }
+
     sails.sockets.broadcast(
       `board:${card.boardId}`,
       'cardCreate',


### PR DESCRIPTION
## What’s new

- Added support for setting custom fields when creating a card via the API.
- Now you can pass a `customFields` object in the request body to `/api/lists/{listId}/cards`.
- Custom field values will be set automatically if the specified group and field exist.

![CleanShot 2025-07-04 at 21 50 50](https://github.com/user-attachments/assets/8e3198df-bf95-4410-929f-343684dd4807)


---

## Usage Example

**Endpoint:**  
POST `/api/lists/{listId}/cards`

**Request Body:**
```json
{
  "name": "Test card with custom field",
  "position": 1,
  "type": "project",
  "customFields": {
    "intern": {
      "SapID": "5635666"
    }
  }
}
```

- `intern` — the name of the custom field group.
- `SapID` — the name of the field within the group.
- `"5635666"` — the value to set.

> **Note:** The group and field must already exist in the Planka interface. If they do not exist, the values will be ignored.

---

## Example Success Response

```json
{
  "item": {
    "id": "1547345490861067225",
    "createdAt": "2025-07-04T17:19:16.631Z",
    "updatedAt": null,
    "type": "project",
    "position": 1,
    "name": "Test card with custom field",
    "description": null,
    "dueDate": null,
    "stopwatch": null,
    "commentsTotal": 0,
    "listChangedAt": "2025-07-04T17:19:16.628Z",
    "boardId": "1526128618923623429",
    "listId": "1530421234892801130",
    "creatorUserId": "1526127733044675585",
    "prevListId": null,
    "coverAttachmentId": null
  }
}
```

---

## Notes & Limitations

- If the specified custom field group or field does not exist, the value will be ignored, but the card will still be created.
- If everything matches, the custom field values will be set immediately on card creation.
- This feature is useful for integrations with external systems (e.g., to automatically create cards with unique identifiers).

---

Closes #1155