### PR TITLE
Fix: typo in en-GB local for email notification

### DIFF
--- a/server/config/locales/en-GB.json
+++ b/server/config/locales/en-GB.json
@@ -6,7 +6,7 @@
   "This is a test text message!": "This is a test text message!",
   "This is a *test* **markdown** `message`!": "This is a *test* **markdown** `message`!",
   "This is a <i>test</i> <b>html</b> <code>message</code>": "This is a <i>test</i> <b>html</b> <code>message</code>",
-  "You Were Added to Card": "Your Were Added to Card",
+  "You Were Added to Card": "You Were Added to Card",
   "You Were Mentioned in Comment": "You Were Mentioned in Comment",
   "%s added you to %s on %s": "%s added you to %s on %s",
   "%s created %s in %s on %s": "%s created %s in %s on %s",


### PR DESCRIPTION
This pull request corrects a typo in the en-GB translation for sending a notification email to users who are added to a card.

- The email that is sent currently reads: "Your Were Added To A Card"
- But should read: "You Were Added To A Card"

Thank you for considering this small change, and for your work on this excellent project!