### PR TITLE
Fix: typo in en-GB and en-US locales

### DIFF
--- a/server/config/locales/en-GB.json
+++ b/server/config/locales/en-GB.json
@@ -6,7 +6,7 @@
   "This is a test text message!": "This is a test text message!",
   "This is a *test* **markdown** `message`!": "This is a *test* **markdown** `message`!",
   "This is a <i>test</i> <b>html</b> <code>message</code>": "This is a <i>test</i> <b>html</b> <code>message</code>",
-  "You Were Added to Card": "Your Were Added to Card",
+  "You Were Added to Card": "You Were Added to Card",
   "You Were Mentioned in Comment": "You Were Mentioned in Comment",
   "%s added you to %s on %s": "%s added you to %s on %s",
   "%s created %s in %s on %s": "%s created %s in %s on %s",

--- a/server/config/locales/en-US.json
+++ b/server/config/locales/en-US.json
@@ -6,7 +6,7 @@
 	"This is a test text message!": "This is a test text message!",
 	"This is a *test* **markdown** `message`!": "This is a *test* **markdown** `message`!",
 	"This is a <i>test</i> <b>html</b> <code>message</code>": "This is a <i>test</i> <b>html</b> <code>message</code>",
-	"You Were Added to Card": "Your Were Added to Card",
+	"You Were Added to Card": "You Were Added to Card",
 	"You Were Mentioned in Comment": "You Were Mentioned in Comment",
 	"%s added you to %s on %s": "%s added you to %s on %s",
 	"%s created %s in %s on %s": "%s created %s in %s on %s",


### PR DESCRIPTION
This pull request addresses a typo in the two English translations when an email notification is sent

- Currently, the email reads: "Your Were Added to Card"
- The email should read: "You Were Added to Card"

This typo is present in both en-US and en-GB.

Thank you for considering this small change, and for all your excellent work on the project!