### PR TITLE
feat: Persist board filters in localStorage

### DIFF
--- a/client/src/models/Board.js
+++ b/client/src/models/Board.js
@@ -161,7 +161,6 @@ export default class extends BaseModel {
 
         if (payload.replace) {
           boardModel.filterUsers.clear();
-          // Clear localStorage filters when replacing
           clearBoardFilters(payload.boardId);
         }
 
@@ -451,7 +450,6 @@ export default class extends BaseModel {
   deleteClearable() {
     this.filterUsers.clear();
     this.filterLabels.clear();
-    // Clear localStorage filters for this board
     clearBoardFilters(this.id);
   }
 

--- a/client/src/models/Board.js
+++ b/client/src/models/Board.js
@@ -14,7 +14,6 @@ import { BoardContexts, BoardViews } from '../constants/Enums';
 import { getBoardFiltersFromStorage, clearBoardFilters } from '../utils/localStorage';
 
 const prepareFetchedBoard = (board) => {
-  // Get stored filters from localStorage
   const storedFilters = getBoardFiltersFromStorage(board.id);
 
   return {
@@ -23,7 +22,6 @@ const prepareFetchedBoard = (board) => {
     context: BoardContexts.BOARD,
     view: board.defaultView,
     search: '',
-    // Restore stored filters
     filterLabels: storedFilters.labels,
     filterUsers: storedFilters.users,
   };

--- a/client/src/models/Board.js
+++ b/client/src/models/Board.js
@@ -11,14 +11,23 @@ import { isListFinite } from '../utils/record-helpers';
 import ActionTypes from '../constants/ActionTypes';
 import Config from '../constants/Config';
 import { BoardContexts, BoardViews } from '../constants/Enums';
+import { getBoardFiltersFromStorage, clearBoardFilters } from '../utils/localStorage';
 
-const prepareFetchedBoard = (board) => ({
-  ...board,
-  isFetching: false,
-  context: BoardContexts.BOARD,
-  view: board.defaultView,
-  search: '',
-});
+const prepareFetchedBoard = (board) => {
+  // Get stored filters from localStorage
+  const storedFilters = getBoardFiltersFromStorage(board.id);
+
+  return {
+    ...board,
+    isFetching: false,
+    context: BoardContexts.BOARD,
+    view: board.defaultView,
+    search: '',
+    // Restore stored filters
+    filterLabels: storedFilters.labels,
+    filterUsers: storedFilters.users,
+  };
+};
 
 export default class extends BaseModel {
   static modelName = 'Board';
@@ -154,6 +163,8 @@ export default class extends BaseModel {
 
         if (payload.replace) {
           boardModel.filterUsers.clear();
+          // Clear localStorage filters when replacing
+          clearBoardFilters(payload.boardId);
         }
 
         boardModel.filterUsers.add(payload.id);
@@ -442,6 +453,8 @@ export default class extends BaseModel {
   deleteClearable() {
     this.filterUsers.clear();
     this.filterLabels.clear();
+    // Clear localStorage filters for this board
+    clearBoardFilters(this.id);
   }
 
   deleteRelated(exceptMemberUserId) {

--- a/client/src/sagas/core/services/labels.js
+++ b/client/src/sagas/core/services/labels.js
@@ -185,7 +185,6 @@ export function* handleLabelFromCardRemove(cardLabel) {
 export function* addLabelToBoardFilter(id, boardId) {
   const currentListId = yield select(selectors.selectCurrentListId);
 
-  // Save to localStorage
   addLabelToBoardFilters(boardId, id);
 
   yield put(actions.addLabelToBoardFilter(id, boardId, currentListId));
@@ -200,7 +199,6 @@ export function* addLabelToFilterInCurrentBoard(id) {
 export function* removeLabelFromBoardFilter(id, boardId) {
   const currentListId = yield select(selectors.selectCurrentListId);
 
-  // Remove from localStorage
   removeLabelFromBoardFilters(boardId, id);
 
   yield put(actions.removeLabelFromBoardFilter(id, boardId, currentListId));

--- a/client/src/sagas/core/services/labels.js
+++ b/client/src/sagas/core/services/labels.js
@@ -10,6 +10,7 @@ import selectors from '../../../selectors';
 import actions from '../../../actions';
 import api from '../../../api';
 import { createLocalId } from '../../../utils/local-id';
+import { addLabelToBoardFilters, removeLabelFromBoardFilters } from '../../../utils/localStorage';
 
 export function* createLabel(boardId, data) {
   const localId = yield call(createLocalId);
@@ -184,6 +185,9 @@ export function* handleLabelFromCardRemove(cardLabel) {
 export function* addLabelToBoardFilter(id, boardId) {
   const currentListId = yield select(selectors.selectCurrentListId);
 
+  // Save to localStorage
+  addLabelToBoardFilters(boardId, id);
+
   yield put(actions.addLabelToBoardFilter(id, boardId, currentListId));
 }
 
@@ -195,6 +199,9 @@ export function* addLabelToFilterInCurrentBoard(id) {
 
 export function* removeLabelFromBoardFilter(id, boardId) {
   const currentListId = yield select(selectors.selectCurrentListId);
+
+  // Remove from localStorage
+  removeLabelFromBoardFilters(boardId, id);
 
   yield put(actions.removeLabelFromBoardFilter(id, boardId, currentListId));
 }

--- a/client/src/sagas/core/services/users.js
+++ b/client/src/sagas/core/services/users.js
@@ -15,6 +15,7 @@ import { setAccessToken } from '../../../utils/access-token-storage';
 import mergeRecords from '../../../utils/merge-records';
 import { isUserAdminOrProjectOwner } from '../../../utils/record-helpers';
 import { UserRoles } from '../../../constants/Enums';
+import { addUserToBoardFilters, removeUserFromBoardFilters } from '../../../utils/localStorage';
 
 export function* createUser(data) {
   yield put(actions.createUser(data));
@@ -429,6 +430,9 @@ export function* handleUserFromCardRemove(cardMembership) {
 export function* addUserToBoardFilter(id, boardId, replace) {
   const currentListId = yield select(selectors.selectCurrentListId);
 
+  // Save to localStorage
+  addUserToBoardFilters(boardId, id);
+
   yield put(actions.addUserToBoardFilter(id, boardId, replace, currentListId));
 }
 
@@ -440,6 +444,9 @@ export function* addUserToFilterInCurrentBoard(id, replace) {
 
 export function* removeUserFromBoardFilter(id, boardId) {
   const currentListId = yield select(selectors.selectCurrentListId);
+
+  // Remove from localStorage
+  removeUserFromBoardFilters(boardId, id);
 
   yield put(actions.removeUserFromBoardFilter(id, boardId, currentListId));
 }

--- a/client/src/sagas/core/services/users.js
+++ b/client/src/sagas/core/services/users.js
@@ -430,7 +430,6 @@ export function* handleUserFromCardRemove(cardMembership) {
 export function* addUserToBoardFilter(id, boardId, replace) {
   const currentListId = yield select(selectors.selectCurrentListId);
 
-  // Save to localStorage
   addUserToBoardFilters(boardId, id);
 
   yield put(actions.addUserToBoardFilter(id, boardId, replace, currentListId));
@@ -445,7 +444,6 @@ export function* addUserToFilterInCurrentBoard(id, replace) {
 export function* removeUserFromBoardFilter(id, boardId) {
   const currentListId = yield select(selectors.selectCurrentListId);
 
-  // Remove from localStorage
   removeUserFromBoardFilters(boardId, id);
 
   yield put(actions.removeUserFromBoardFilter(id, boardId, currentListId));

--- a/client/src/utils/localStorage.js
+++ b/client/src/utils/localStorage.js
@@ -1,0 +1,79 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const BOARD_FILTERS_KEY = 'planka-board-filters';
+
+export const getBoardFiltersFromStorage = (boardId) => {
+  try {
+    const storedFilters = localStorage.getItem(BOARD_FILTERS_KEY);
+    if (!storedFilters) return { labels: [], users: [] };
+
+    const filters = JSON.parse(storedFilters);
+    return filters[boardId] || { labels: [], users: [] };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to load board filters from localStorage:', error);
+    return { labels: [], users: [] };
+  }
+};
+
+export const saveBoardFiltersToStorage = (boardId, filters) => {
+  try {
+    const storedFilters = localStorage.getItem(BOARD_FILTERS_KEY);
+    const allFilters = storedFilters ? JSON.parse(storedFilters) : {};
+
+    allFilters[boardId] = filters;
+    localStorage.setItem(BOARD_FILTERS_KEY, JSON.stringify(allFilters));
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to save board filters to localStorage:', error);
+  }
+};
+
+export const addLabelToBoardFilters = (boardId, labelId) => {
+  const filters = getBoardFiltersFromStorage(boardId);
+  if (!filters.labels.includes(labelId)) {
+    filters.labels.push(labelId);
+    saveBoardFiltersToStorage(boardId, filters);
+  }
+  return filters.labels;
+};
+
+export const removeLabelFromBoardFilters = (boardId, labelId) => {
+  const filters = getBoardFiltersFromStorage(boardId);
+  filters.labels = filters.labels.filter((id) => id !== labelId);
+  saveBoardFiltersToStorage(boardId, filters);
+  return filters.labels;
+};
+
+export const addUserToBoardFilters = (boardId, userId) => {
+  const filters = getBoardFiltersFromStorage(boardId);
+  if (!filters.users.includes(userId)) {
+    filters.users.push(userId);
+    saveBoardFiltersToStorage(boardId, filters);
+  }
+  return filters.users;
+};
+
+export const removeUserFromBoardFilters = (boardId, userId) => {
+  const filters = getBoardFiltersFromStorage(boardId);
+  filters.users = filters.users.filter((id) => id !== userId);
+  saveBoardFiltersToStorage(boardId, filters);
+  return filters.users;
+};
+
+export const clearBoardFilters = (boardId) => {
+  try {
+    const storedFilters = localStorage.getItem(BOARD_FILTERS_KEY);
+    if (storedFilters) {
+      const allFilters = JSON.parse(storedFilters);
+      delete allFilters[boardId];
+      localStorage.setItem(BOARD_FILTERS_KEY, JSON.stringify(allFilters));
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to clear board filters from localStorage:', error);
+  }
+};


### PR DESCRIPTION

![CleanShot 2025-09-03 at 09 35 09](https://github.com/user-attachments/assets/cdba9e0f-6f8a-4d98-b5bd-fb5a9458cb85)


- **Persistent Label Filters**: Selected labels are now saved and restored across browser sessions
- **Persistent User Filters**: Selected users are now saved and restored across browser sessions  
- **Per-Board Storage**: Each board maintains its own independent filter state
- **Error Handling**: Graceful fallbacks if localStorage is unavailable
- **Clean Integration**: Follows existing code patterns and maintains backward compatibility

### New Files
- `client/src/utils/localStorage.js` - Utility functions for managing board filters in localStorage

### Modified Files
- `client/src/sagas/core/services/labels.js` - Updated label filter functions to save/restore from localStorage
- `client/src/sagas/core/services/users.js` - Updated user filter functions to save/restore from localStorage  
- `client/src/models/Board.js` - Modified to restore filters on board load and handle clearing

### Key Functions
- `addLabelToBoardFilters()` / `removeLabelFromBoardFilters()` - Manage label persistence
- `addUserToBoardFilters()` / `removeUserFromBoardFilters()` - Manage user persistence
- `getBoardFiltersFromStorage()` - Restore filters when loading boards
- `clearBoardFilters()` - Handle filter clearing scenarios

## How It Works

1. **When filters are added**: Immediately saved to localStorage with board-specific keys
2. **When filters are removed**: Immediately removed from localStorage
3. **When boards are loaded**: Previously saved filters are automatically restored
4. **When filters are cleared**: localStorage is also cleared for that board

- **Before**: Users had to re-select filters every time they returned to a board
- **After**: Filters persist automatically across sessions, tabs, and browser restarts

Closes: #1311