### PR TITLE
Minor helm chart updates

### DIFF
--- a/charts/planka/Chart.yaml
+++ b/charts/planka/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-rc.3"
+appVersion: "2.0.0-rc.4"
 
 dependencies:
   - alias: postgresql

--- a/charts/planka/templates/ingress.yaml
+++ b/charts/planka/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "planka.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -68,6 +68,7 @@ service:
 ingress:
   enabled: false
   className: ""
+  labels: {}
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -108,6 +109,11 @@ tolerations: []
 affinity: {}
 
 postgresql:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   enabled: true
   auth:
     database: planka


### PR DESCRIPTION
- Updated postgres chart to use legacy repository(bitnamilegacy) even though it's required to pass "allowInsecureImages"
- Added labels for ingress. This is in order to allow service like homepage(https://github.com/gethomepage/homepage) to fetch ingress dynamically and add it to dashboard