### PR TITLE
fix: show button when have text content in comments input (#1350)

### DIFF
--- a/client/src/components/comments/Comments/Add.jsx
+++ b/client/src/components/comments/Comments/Add.jsx
@@ -173,7 +173,7 @@ const Add = React.memo(() => {
           />
         </MentionsInput>
       </div>
-      {isOpened && (
+      {(isOpened || data.text.length > 0) && (
         <div className={styles.controls}>
           <Button
             {...clickAwayProps} // eslint-disable-line react/jsx-props-no-spreading


### PR DESCRIPTION
This close #1350.

This is a simple fix. Just check if there have content in comments input.