### PR TITLE
fix: Add missing keys to chart values file

### DIFF
--- a/charts/planka/Chart.yaml
+++ b/charts/planka/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -27,10 +27,10 @@ existingSecretkeySecret: ""
 ## NOTE: When it's set, the `admin_username` and `admin_password` parameters are ignored
 existingAdminCredsSecret: ""
 
-admin_username: ""
+admin_email: ""
 admin_password: ""
 admin_name: ""
-admin_email: ""
+admin_username: ""
 
 # Base url for PLANKA. Will override `ingress.hosts[0].host`
 # Defaults to `http://localhost:3000` if ingress is disabled.


### PR DESCRIPTION
Without a username and email, you can not log into the account. While they were being silently used in the template already, there was no indication of it.

I chose not to populate these from the secret, as it would be a breaking change to people that now manually specify it

It would also probably be nicer to separate the whole admin section, but that is a breaking change as well