### PR TITLE
Add cross-platform support for date command in backup script

### DIFF
--- a/docker-backup.sh
+++ b/docker-backup.sh
@@ -8,7 +8,13 @@ PLANKA_DOCKER_CONTAINER_POSTGRES="planka-postgres-1"
 PLANKA_DOCKER_CONTAINER_PLANKA="planka-planka-1"
 
 # Create Temporary folder
-BACKUP_DATETIME=$(date --utc +%FT%H-%M-%SZ)
+if date --version >/dev/null 2>&1; then
+    # GNU date (Linux)
+    BACKUP_DATETIME=$(date --utc +%FT%H-%M-%SZ)
+else
+    # BSD date (macOS)
+    BACKUP_DATETIME=$(date -u +%FT%H-%M-%SZ)
+fi
 mkdir -p "$BACKUP_DATETIME-backup"
 
 # Dump DB into SQL File


### PR DESCRIPTION
## Description

Fixes the `date: illegal option -- -` error that occurs when running backup scripts on macOS.

The `date` command has different syntax between GNU (Linux) and BSD (macOS). This PR adds cross-platform compatibility by detecting the OS and using the appropriate flag.

## Changes

- Add OS detection for GNU vs BSD date syntax
- Use `--utc` flag on Linux, `-u` flag on macOS
- Ensures backup datetime generation works on both platforms

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Tested on:
- [x] macOS (BSD date)
- [ ] Linux (GNU date)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published