### PR TITLE
chore: Add chart to feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -5,7 +5,7 @@ body:
   - type: dropdown
     id: idea-type
     attributes:
-      label: Is this a feature for the backend, frontend, or the Helm chart?
+      label: Which part of the project does this feature apply to?
       multiple: true
       options:
         - Backend


### PR DESCRIPTION
It was previously not possible to open an issue with the feature request template for the Helm chart, as selecting either the backend or frontend was necessary