### PR TITLE
Fix: Mount writable emptyDir volumes for readOnlyRootFilesystem support

### DIFF
--- a/charts/planka/templates/deployment.yaml
+++ b/charts/planka/templates/deployment.yaml
@@ -70,6 +70,12 @@ spec:
             - mountPath: /app/logs
               subPath: app-logs
               name: emptydir
+            - mountPath: /app/.tmp
+              subPath: app-tmp
+              name: emptydir
+            - mountPath: /tmp
+              subPath: tmp
+              name: emptydir
           {{- end }}
           {{- /* Extra volume mounts */}}
           {{- range .Values.extraMounts }}


### PR DESCRIPTION
When securityContext.readOnlyRootFilesystem: true is set, the container fails  due to two missing paths requiring write access:

/tmp — Planka requires write access to /tmp at runtime. Without it the container fails to start entirely.
/app/.tmp — Planka uses this directory probably as a staging area for file uploads. Without a writable mount, attachment uploads in a given task silently fail with no error shown in the UI, making this particularly hard to diagnose.

This PR extends the existing readOnlyRootFilesystem emptyDir handling (which previously only covered /app/logs) to also mount writable emptyDir subPaths at /tmp and /app/.tmp.
