### PR TITLE
Set fsGroup in podSecurityContext for proper volume permissions

### DIFF
--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -51,8 +51,8 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 1000
 
 # Annotations to add to the deployment
 deploymentAnnotations: {}


### PR DESCRIPTION
Fixes #956

## Summary
This PR fixes a permission issue in the Helm chart where `project-background-images` and `user-avatars` directories were mounted with root ownership, preventing file uploads from working with "permission denied" errors.

The fix sets `fsGroup: 1000` in the `podSecurityContext` to ensure that mounted volumes are accessible by the application's non-root user, enabling proper file upload functionality out of the box.

## Changes
- Updated `charts/planka/values.yaml` to set `podSecurityContext.fsGroup: 1000` instead of an empty configuration
- This ensures all volumes mounted to the pod are owned by group ID 1000, matching the application user

## Testing
- Verified YAML syntax is valid
- The change follows Kubernetes best practices for running containers as non-root users with persistent storage
- Users can still override this value in their custom values.yaml if needed

## Diff Stats
```
 charts/planka/values.yaml | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```