### PR TITLE
fix: unicode/emoji characters in user avatar initials

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -45,7 +45,6 @@
         "history": "^5.3.0",
         "i18next": "^25.8.18",
         "i18next-browser-languagedetector": "^8.2.1",
-        "initials": "^3.1.2",
         "javascript-time-ago": "^2.6.4",
         "js-cookie": "^3.0.5",
         "jwt-decode": "^4.0.0",
@@ -10585,12 +10584,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/initials": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/initials/-/initials-3.1.2.tgz",
-      "integrity": "sha512-Sltg35nx8+GX1w4U86rmbxFEmqFiSuMJviS6cB2KChB+jcT2/8Td+nlImXD74HkqpZF5PMv8hN57AyrA/7ltXw==",
-      "license": "MIT"
     },
     "node_modules/inline-style-prefixer": {
       "version": "7.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -122,7 +122,6 @@
     "history": "^5.3.0",
     "i18next": "^25.8.18",
     "i18next-browser-languagedetector": "^8.2.1",
-    "initials": "^3.1.2",
     "javascript-time-ago": "^2.6.4",
     "js-cookie": "^3.0.5",
     "jwt-decode": "^4.0.0",

--- a/client/src/components/users/UserAvatar/UserAvatar.jsx
+++ b/client/src/components/users/UserAvatar/UserAvatar.jsx
@@ -5,7 +5,6 @@
 
 import upperFirst from 'lodash/upperFirst';
 import camelCase from 'lodash/camelCase';
-import initials from 'initials';
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -34,6 +33,19 @@ const COLORS = [
   'turquoise',
   'midnight-blue',
 ];
+
+const getInitials = (name) => {
+  const words = name
+    .trim()
+    .split(/[\s-]+/)
+    .filter(Boolean);
+  if (words.length === 0) return '';
+  if (words.length === 1) return [...words[0]].slice(0, 2).join('');
+  return words
+    .slice(0, 2)
+    .map((word) => [...word][0])
+    .join('');
+};
 
 const getColor = (name) => {
   let sum = 0;
@@ -78,7 +90,7 @@ const UserAvatar = React.memo(
           background: avatarUrl && `url("${avatarUrl}") center / cover`,
         }}
       >
-        {!avatarUrl && <span className={styles.initials}>{initials(user.name).slice(0, 2)}</span>}
+        {!avatarUrl && <span className={styles.initials}>{getInitials(user.name)}</span>}
         {withCreatorIndicator && <span className={styles.creatorIndicator}>+</span>}
       </span>
     );


### PR DESCRIPTION
The `initials` npm library is not Unicode-aware — it operates on UTF-16 code units rather than Unicode code points. This caused emoji (e.g. 🤖) and other misc characters in user names to render as broken replacement characters in avatar badges, since emoji are surrogate pairs (2 code units) and string[n] splits them in half.

- Removed the `initials` dependency entirely (was anyway crazy to include it simply for this)
- Replaced it with a small inline `getInitials()` that uses ES6 spread ([...str]) to iterate by Unicode code points
- Hyphenated names (Jean-Luc Picard → JL) are correctly handled, preserving the main useful behaviour of the old library

> Before: "Bot 🤖" → "C\uD83E" (broken) After: "Bot 🤖" → "B🤖"

Cheers
Hannes
