### PR TITLE
Fix archive card keyboard shortcut mapped to wrong key

### DIFF
--- a/client/src/components/boards/Board/ShortcutsProvider.jsx
+++ b/client/src/components/boards/Board/ShortcutsProvider.jsx
@@ -393,7 +393,7 @@ const ShortcutsProvider = React.memo(({ children }) => {
           handleCardNameEdit(event);
 
           break;
-        case 'KeyV':
+        case 'KeyC':
           handleCardArchive(event);
 
           break;


### PR DESCRIPTION
The 'c' shortcut for archiving a hovered card was bound to 'KeyV' instead of 'KeyC'.

Fixes https://github.com/plankanban/planka/issues/1641