### PR TITLE
feat: allow re-ordering cards in list view

### DIFF
--- a/client/src/components/boards/Board/FiniteContent.jsx
+++ b/client/src/components/boards/Board/FiniteContent.jsx
@@ -46,6 +46,7 @@ const FiniteContent = React.memo(() => {
   return (
     <View
       cardIds={cardIds}
+      isReorderingEnabled={board.view === BoardViews.LIST}
       onCardCreate={canAddCard ? handleCardCreate : undefined}
       onCardPaste={canAddCard ? handleCardPaste : undefined}
     />

--- a/client/src/components/boards/Board/ListView.jsx
+++ b/client/src/components/boards/Board/ListView.jsx
@@ -6,21 +6,38 @@
 import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { shallowEqual, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux';
 import { useInView } from 'react-intersection-observer';
 import { useTranslation } from 'react-i18next';
 import { Button, Icon, Loader } from 'semantic-ui-react';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 
 import selectors from '../../../selectors';
+import entryActions from '../../../entry-actions';
 import { BoardMembershipRoles } from '../../../constants/Enums';
+import DroppableTypes from '../../../constants/DroppableTypes';
+import parseDndId from '../../../utils/parse-dnd-id';
+import { closePopup } from '../../../lib/popup';
+import globalStyles from '../../../styles.module.scss';
 import Card from '../../cards/Card';
+import DraggableCard from '../../cards/DraggableCard';
 import AddCard from '../../cards/AddCard';
 import PlusMathIcon from '../../../assets/images/plus-math-icon.svg?react';
 
 import styles from './ListView.module.scss';
 
 const ListView = React.memo(
-  ({ cardIds, isCardsFetching, isAllCardsFetched, onCardsFetch, onCardCreate, onCardPaste }) => {
+  ({
+    cardIds,
+    isCardsFetching,
+    isAllCardsFetched,
+    isReorderingEnabled,
+    onCardsFetch,
+    onCardCreate,
+    onCardPaste,
+  }) => {
+    const store = useStore();
+    const dispatch = useDispatch();
     const clipboard = useSelector(selectors.selectClipboard);
 
     const { canAddCard, canPasteCard } = useSelector((state) => {
@@ -52,6 +69,94 @@ const ListView = React.memo(
     const handleAddCardClose = useCallback(() => {
       setIsAddCardOpened(false);
     }, []);
+
+    const handleDragStart = useCallback(() => {
+      document.body.classList.add(globalStyles.dragging);
+      closePopup();
+    }, []);
+
+    const handleDragEnd = useCallback(
+      ({ draggableId, type, source, destination }) => {
+        document.body.classList.remove(globalStyles.dragging);
+
+        if (!destination || type !== DroppableTypes.CARD) {
+          return;
+        }
+
+        if (source.index === destination.index) {
+          return;
+        }
+
+        const cardId = parseDndId(draggableId);
+        const state = store.getState();
+        const getListId = (id) => {
+          const card = id ? selectors.selectCardById(state, id) : null;
+          return card ? card.listId : null;
+        };
+
+        const newOrder = cardIds.filter((id) => id !== cardId);
+        const prevId = destination.index > 0 ? newOrder[destination.index - 1] : null;
+        const nextId = destination.index < newOrder.length ? newOrder[destination.index] : null;
+
+        const targetListId = getListId(prevId) || getListId(nextId);
+        if (!targetListId) {
+          return;
+        }
+
+        let localIndex = 0;
+        for (let i = 0; i < destination.index; i += 1) {
+          if (getListId(newOrder[i]) === targetListId) {
+            localIndex += 1;
+          }
+        }
+
+        dispatch(entryActions.moveCard(cardId, targetListId, localIndex));
+      },
+      [cardIds, dispatch, store],
+    );
+
+    const renderCardsContent = () => {
+      if (cardIds.length === 0) {
+        return null;
+      }
+
+      if (!isReorderingEnabled) {
+        return (
+          <div className={classNames(styles.segment, styles.cards)}>
+            {cardIds.map((cardId, cardIndex) => (
+              <div key={cardId} className={styles.card}>
+                <Card isInline id={cardId} index={cardIndex} />
+              </div>
+            ))}
+          </div>
+        );
+      }
+
+      return (
+        <DragDropContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+          <Droppable droppableId="list-view" type={DroppableTypes.CARD}>
+            {({ innerRef, droppableProps, placeholder }) => (
+              <div
+                {...droppableProps} // eslint-disable-line react/jsx-props-no-spreading
+                ref={innerRef}
+                className={classNames(styles.segment, styles.cards)}
+              >
+                {cardIds.map((cardId, cardIndex) => (
+                  <DraggableCard
+                    key={cardId}
+                    isInline
+                    id={cardId}
+                    index={cardIndex}
+                    className={styles.card}
+                  />
+                ))}
+                {placeholder}
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
+      );
+    };
 
     return (
       <div className={styles.wrapper}>
@@ -85,15 +190,7 @@ const ListView = React.memo(
               )}
             </div>
           ))}
-        {cardIds.length > 0 && (
-          <div className={classNames(styles.segment, styles.cards)}>
-            {cardIds.map((cardId, cardIndex) => (
-              <div key={cardId} className={styles.card}>
-                <Card isInline id={cardId} index={cardIndex} />
-              </div>
-            ))}
-          </div>
-        )}
+        {renderCardsContent()}
         {isCardsFetching !== undefined && isAllCardsFetched !== undefined && (
           <div className={styles.loaderWrapper}>
             {isCardsFetching ? (
@@ -112,6 +209,7 @@ ListView.propTypes = {
   cardIds: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   isCardsFetching: PropTypes.bool,
   isAllCardsFetched: PropTypes.bool,
+  isReorderingEnabled: PropTypes.bool,
   onCardsFetch: PropTypes.func,
   onCardCreate: PropTypes.func,
   onCardPaste: PropTypes.func,
@@ -120,6 +218,7 @@ ListView.propTypes = {
 ListView.defaultProps = {
   isCardsFetching: undefined,
   isAllCardsFetched: undefined,
+  isReorderingEnabled: false,
   onCardsFetch: undefined,
   onCardCreate: undefined,
   onCardPaste: undefined,


### PR DESCRIPTION
  Closes #1525.

  Enables drag-and-drop re-ordering of cards directly in the List view, mirroring the behavior already available in the Kanban view. Previously, the list view rendered cards as a flat,
  read-only list — users had to switch back to Kanban to reorder or move cards between lists.

  What changed

  - client/src/components/boards/Board/ListView.jsx
    - Wrapped the card list in DragDropContext + a single Droppable of type CARD.
    - Replaced the plain <Card isInline /> with <DraggableCard isInline />.
    - Added handleDragStart / handleDragEnd handlers. Since the list view is flat across multiple lists, the drop handler translates the flat destination index into (targetListId, localIndex)
   by inspecting the previous neighbor card's list (or the next neighbor's, when dropped at the very top), then dispatches the existing entryActions.moveCard.
    - Reordering is gated by a new isReorderingEnabled prop (default false), so the same component stays read-only when used in archive/trash contexts.
  - client/src/components/boards/Board/FiniteContent.jsx
    - Passes isReorderingEnabled={board.view === BoardViews.LIST} so DnD turns on for the board-level list view but stays off for grid view. EndlessContent (archive/trash) doesn't pass the
  prop, so drag stays disabled there — those views are sorted by listChangedAt, not position.

  Reused (no changes)

  - entryActions.moveCard(id, listId, index) — already handles both same-list reorder and cross-list move.
  - services/cards.js saga moveCard + selectors/positioning.js nextPosition — already compute fractional positions for arbitrary insertions.
  - DraggableCard — already enforces editor-only drag permissions and respects isPersisted.
  - Server PATCH /api/cards/:id — already accepts position (and listId for cross-list moves).

  No backend changes were necessary.

  Drop semantics

  - Drop a card next to another card from the same list → reorders within that list.
  - Drop a card next to a card from a different list → moves the card into that list at the corresponding position (the inline list-name tag updates accordingly).
  - Drop at the same index → no-op, no request fired.

  Test plan

  - Switch a board to List view and drag a card up/down within its own list section — order updates and persists across reload.
  - Drag a card so it lands next to a card of a different list — the card moves into that list (verify by switching to Kanban view).
  - Open DevTools → Network: each drop fires PATCH /api/cards/:id with position (and listId for cross-list drops); response is 200.
  - Log in as a non-editor (viewer) — cards are not draggable.
  - Open archive/trash via the per-list endless view — drag is disabled there.
  - Switch back to Kanban view — existing list/card drag-and-drop still works exactly as before (no regressions in KanbanContent).
  - cd client && npm run lint passes.
  - cd client && npm run build passes.

  Out of scope

  - Status/list filter in list view (tracked separately).
  - Reordering inside archive/trash views.
  - Section headers / grouped list view layout — the existing flat layout with inline list-name tags is retained.