### PR TITLE
feat: clickable label region on cards (closes #1626)

### DIFF
--- a/client/src/components/boards/BoardSettingsModal/PreferencesPane/Others.jsx
+++ b/client/src/components/boards/BoardSettingsModal/PreferencesPane/Others.jsx
@@ -59,6 +59,14 @@ const Others = React.memo(() => {
         className={styles.radio}
         onChange={handleChange}
       />
+      <Radio
+        toggle
+        name="displayLabelPlaceholderOnUnlabeledCards"
+        checked={board.displayLabelPlaceholderOnUnlabeledCards}
+        label={t('common.displayLabelPlaceholderOnUnlabeledCards')}
+        className={styles.radio}
+        onChange={handleChange}
+      />
     </Segment>
   );
 });

--- a/client/src/components/cards/Card/InlineContent.jsx
+++ b/client/src/components/cards/Card/InlineContent.jsx
@@ -3,17 +3,21 @@
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Icon } from 'semantic-ui-react';
 
 import selectors from '../../../selectors';
+import entryActions from '../../../entry-actions';
+import { usePopup } from '../../../lib/popup';
+import { isListArchiveOrTrash } from '../../../utils/record-helpers';
 import markdownToText from '../../../utils/markdown-to-text';
-import { BoardViews } from '../../../constants/Enums';
+import { BoardMembershipRoles, BoardViews } from '../../../constants/Enums';
 import UserAvatar from '../../users/UserAvatar';
 import LabelChip from '../../labels/LabelChip';
+import LabelsStep from '../../labels/LabelsStep';
 
 import styles from './InlineContent.module.scss';
 
@@ -35,19 +39,48 @@ const InlineContent = React.memo(({ cardId }) => {
     selectNotificationsTotalByCardId(state, cardId),
   );
 
-  const listName = useSelector((state) => {
-    if (!list.name) {
-      return null;
+  const { listName, withLabelPlaceholder } = useSelector((state) => {
+    const board = selectors.selectCurrentBoard(state);
+    const view = board && board.view;
+
+    return {
+      listName: list.name && view !== BoardViews.KANBAN ? list.name : null,
+      withLabelPlaceholder: !!board && board.displayLabelPlaceholderOnUnlabeledCards,
+    };
+  }, shallowEqual);
+
+  const canEditLabels = useSelector((state) => {
+    if (isListArchiveOrTrash(list)) {
+      return false;
     }
 
-    const { view } = selectors.selectCurrentBoard(state);
-
-    if (view === BoardViews.KANBAN) {
-      return null;
-    }
-
-    return list.name;
+    const boardMembership = selectors.selectCurrentUserMembershipForCurrentBoard(state);
+    return !!boardMembership && boardMembership.role === BoardMembershipRoles.EDITOR;
   });
+
+  const dispatch = useDispatch();
+
+  const handleLabelsButtonClick = useCallback((event) => {
+    event.stopPropagation();
+  }, []);
+
+  const handleLabelSelect = useCallback(
+    (labelId) => {
+      dispatch(entryActions.addLabelToCard(labelId, cardId));
+    },
+    [cardId, dispatch],
+  );
+
+  const handleLabelDeselect = useCallback(
+    (labelId) => {
+      dispatch(entryActions.removeLabelFromCard(labelId, cardId));
+    },
+    [cardId, dispatch],
+  );
+
+  const LabelsPopup = usePopup(LabelsStep);
+
+  const showLabelPlaceholder = labelIds.length === 0 && withLabelPlaceholder && canEditLabels;
 
   const descriptionText = useMemo(
     () => card.description && markdownToText(card.description),
@@ -78,15 +111,42 @@ const InlineContent = React.memo(({ cardId }) => {
           )}
         </span>
       )}
-      {labelIds.length > 0 && (
-        <span className={classNames(styles.attachments, styles.hidable)}>
-          {labelIds.map((labelId) => (
-            <span key={labelId} className={classNames(styles.attachment, styles.attachmentLeft)}>
-              <LabelChip id={labelId} size="tiny" />
-            </span>
-          ))}
-        </span>
-      )}
+      {(labelIds.length > 0 || showLabelPlaceholder) &&
+        (canEditLabels ? (
+          <LabelsPopup
+            currentIds={labelIds}
+            cardId={cardId}
+            onSelect={handleLabelSelect}
+            onDeselect={handleLabelDeselect}
+          >
+            <button
+              type="button"
+              onClick={handleLabelsButtonClick}
+              className={classNames(styles.labelsButton, styles.hidable)}
+            >
+              {labelIds.length > 0 ? (
+                labelIds.map((labelId) => (
+                  <span
+                    key={labelId}
+                    className={classNames(styles.attachment, styles.attachmentLeft)}
+                  >
+                    <LabelChip id={labelId} size="tiny" />
+                  </span>
+                ))
+              ) : (
+                <span className={styles.labelsPlaceholder} />
+              )}
+            </button>
+          </LabelsPopup>
+        ) : (
+          <span className={classNames(styles.attachments, styles.hidable)}>
+            {labelIds.map((labelId) => (
+              <span key={labelId} className={classNames(styles.attachment, styles.attachmentLeft)}>
+                <LabelChip id={labelId} size="tiny" />
+              </span>
+            ))}
+          </span>
+        ))}
       <span
         className={classNames(styles.attachments, styles.name, card.isClosed && styles.nameClosed)}
       >

--- a/client/src/components/cards/Card/InlineContent.module.scss
+++ b/client/src/components/cards/Card/InlineContent.module.scss
@@ -44,6 +44,35 @@
     text-overflow: ellipsis;
   }
 
+  .labelsButton {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    margin: 0;
+    outline: none;
+    padding: 0;
+    text-align: left;
+    white-space: nowrap;
+
+    &:not(:last-child) {
+      margin-right: 20px;
+    }
+  }
+
+  .labelsPlaceholder {
+    background: rgba(9, 30, 66, 0.04);
+    border-radius: 3px;
+    display: inline-block;
+    height: 16px;
+    min-width: 40px;
+    transition: background 0.2s ease;
+    vertical-align: middle;
+
+    &:hover {
+      background: rgba(9, 30, 66, 0.08);
+    }
+  }
+
   .name {
     color: #17394d;
     font-size: 14px;

--- a/client/src/components/cards/Card/ProjectContent.jsx
+++ b/client/src/components/cards/Card/ProjectContent.jsx
@@ -11,6 +11,7 @@ import { Icon } from 'semantic-ui-react';
 
 import selectors from '../../../selectors';
 import entryActions from '../../../entry-actions';
+import { usePopup } from '../../../lib/popup';
 import { startStopwatch, stopStopwatch } from '../../../utils/stopwatch';
 import { isListArchiveOrTrash } from '../../../utils/record-helpers';
 import { BoardMembershipRoles, BoardViews } from '../../../constants/Enums';
@@ -20,6 +21,7 @@ import StopwatchChip from '../StopwatchChip';
 import TimeAgo from '../../common/TimeAgo';
 import UserAvatar from '../../users/UserAvatar';
 import LabelChip from '../../labels/LabelChip';
+import LabelsStep from '../../labels/LabelsStep';
 import CustomFieldValueChip from '../../custom-field-values/CustomFieldValueChip';
 
 import styles from './ProjectContent.module.scss';
@@ -76,17 +78,18 @@ const ProjectContent = React.memo(({ cardId }) => {
     return attachment && attachment.data.thumbnailUrls.outside360;
   });
 
-  const { listName, withCreator, withAge } = useSelector((state) => {
+  const { listName, withCreator, withAge, withLabelPlaceholder } = useSelector((state) => {
     const board = selectors.selectCurrentBoard(state);
 
     return {
       listName: list.name && (board.view === BoardViews.KANBAN ? null : list.name),
       withCreator: board.alwaysDisplayCardCreator,
       withAge: board.displayCardAges,
+      withLabelPlaceholder: board.displayLabelPlaceholderOnUnlabeledCards,
     };
   }, shallowEqual);
 
-  const canEditStopwatch = useSelector((state) => {
+  const canEditLabels = useSelector((state) => {
     if (isListArchiveOrTrash(list)) {
       return false;
     }
@@ -94,6 +97,8 @@ const ProjectContent = React.memo(({ cardId }) => {
     const boardMembership = selectors.selectCurrentUserMembershipForCurrentBoard(state);
     return !!boardMembership && boardMembership.role === BoardMembershipRoles.EDITOR;
   });
+
+  const canEditStopwatch = canEditLabels;
 
   const dispatch = useDispatch();
 
@@ -112,6 +117,26 @@ const ProjectContent = React.memo(({ cardId }) => {
     [cardId, card.stopwatch, dispatch],
   );
 
+  const handleLabelsButtonClick = useCallback((event) => {
+    event.stopPropagation();
+  }, []);
+
+  const handleLabelSelect = useCallback(
+    (labelId) => {
+      dispatch(entryActions.addLabelToCard(labelId, cardId));
+    },
+    [cardId, dispatch],
+  );
+
+  const handleLabelDeselect = useCallback(
+    (labelId) => {
+      dispatch(entryActions.removeLabelFromCard(labelId, cardId));
+    },
+    [cardId, dispatch],
+  );
+
+  const LabelsPopup = usePopup(LabelsStep);
+
   const hasInformation =
     card.description ||
     card.dueDate ||
@@ -121,6 +146,8 @@ const ProjectContent = React.memo(({ cardId }) => {
     attachmentsTotal > 0 ||
     notificationsTotal > 0 ||
     listName;
+
+  const showLabelPlaceholder = labelIds.length === 0 && withLabelPlaceholder && canEditLabels;
 
   const isCompact =
     (labelIds.length === 0 || customFieldValueIds.length === 0) &&
@@ -154,15 +181,44 @@ const ProjectContent = React.memo(({ cardId }) => {
           <img src={coverUrl} alt="" className={styles.cover} />
         </div>
       )}
-      {labelIds.length > 0 && (
-        <span className={classNames(styles.labels, !isCompact && styles.labelsFull)}>
-          {labelIds.map((labelId) => (
-            <span key={labelId} className={classNames(styles.attachment, styles.attachmentLeft)}>
-              <LabelChip id={labelId} size="tiny" />
-            </span>
-          ))}
-        </span>
-      )}
+      {(labelIds.length > 0 || showLabelPlaceholder) &&
+        (canEditLabels ? (
+          <LabelsPopup
+            currentIds={labelIds}
+            cardId={cardId}
+            onSelect={handleLabelSelect}
+            onDeselect={handleLabelDeselect}
+          >
+            <button
+              type="button"
+              onClick={handleLabelsButtonClick}
+              className={classNames(styles.labelsButton, !isCompact && styles.labelsButtonFull)}
+            >
+              <span className={classNames(styles.labels, !isCompact && styles.labelsFull)}>
+                {labelIds.length > 0 ? (
+                  labelIds.map((labelId) => (
+                    <span
+                      key={labelId}
+                      className={classNames(styles.attachment, styles.attachmentLeft)}
+                    >
+                      <LabelChip id={labelId} size="tiny" />
+                    </span>
+                  ))
+                ) : (
+                  <span className={styles.labelsPlaceholder} />
+                )}
+              </span>
+            </button>
+          </LabelsPopup>
+        ) : (
+          <span className={classNames(styles.labels, !isCompact && styles.labelsFull)}>
+            {labelIds.map((labelId) => (
+              <span key={labelId} className={classNames(styles.attachment, styles.attachmentLeft)}>
+                <LabelChip id={labelId} size="tiny" />
+              </span>
+            ))}
+          </span>
+        ))}
       {customFieldValueIds.length > 0 && (
         <span className={classNames(styles.labels, !isCompact && styles.labelsFull)}>
           {customFieldValueIds.map((customFieldValueId) => (

--- a/client/src/components/cards/Card/ProjectContent.module.scss
+++ b/client/src/components/cards/Card/ProjectContent.module.scss
@@ -72,8 +72,41 @@
     overflow: hidden;
   }
 
+  .labelsButton {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    display: inline-block;
+    margin: 0;
+    max-width: 100%;
+    outline: none;
+    padding: 0;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  .labelsButtonFull {
+    display: block;
+    width: 100%;
+  }
+
   .labelsFull {
     display: block;
+  }
+
+  .labelsPlaceholder {
+    background: rgba(9, 30, 66, 0.04);
+    border-radius: 3px;
+    display: inline-block;
+    height: 16px;
+    margin: 0 0 6px 0;
+    min-width: 40px;
+    transition: background 0.2s ease;
+    vertical-align: top;
+
+    &:hover {
+      background: rgba(9, 30, 66, 0.08);
+    }
   }
 
   .name {

--- a/client/src/components/cards/Card/StoryContent.jsx
+++ b/client/src/components/cards/Card/StoryContent.jsx
@@ -3,17 +3,21 @@
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { shallowEqual, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Icon } from 'semantic-ui-react';
 
 import selectors from '../../../selectors';
+import entryActions from '../../../entry-actions';
+import { usePopup } from '../../../lib/popup';
+import { isListArchiveOrTrash } from '../../../utils/record-helpers';
+import { BoardMembershipRoles, BoardViews } from '../../../constants/Enums';
 import markdownToText from '../../../utils/markdown-to-text';
-import { BoardViews } from '../../../constants/Enums';
 import TimeAgo from '../../common/TimeAgo';
 import LabelChip from '../../labels/LabelChip';
+import LabelsStep from '../../labels/LabelsStep';
 import CustomFieldValueChip from '../../custom-field-values/CustomFieldValueChip';
 
 import styles from './StoryContent.module.scss';
@@ -53,14 +57,48 @@ const StoryContent = React.memo(({ cardId }) => {
     selectNotificationsTotalByCardId(state, cardId),
   );
 
-  const { listName, withAge } = useSelector((state) => {
+  const { listName, withAge, withLabelPlaceholder } = useSelector((state) => {
     const board = selectors.selectCurrentBoard(state);
 
     return {
       listName: list.name && (board.view === BoardViews.KANBAN ? null : list.name),
       withAge: board.displayCardAges,
+      withLabelPlaceholder: board.displayLabelPlaceholderOnUnlabeledCards,
     };
   }, shallowEqual);
+
+  const canEditLabels = useSelector((state) => {
+    if (isListArchiveOrTrash(list)) {
+      return false;
+    }
+
+    const boardMembership = selectors.selectCurrentUserMembershipForCurrentBoard(state);
+    return !!boardMembership && boardMembership.role === BoardMembershipRoles.EDITOR;
+  });
+
+  const dispatch = useDispatch();
+
+  const handleLabelsButtonClick = useCallback((event) => {
+    event.stopPropagation();
+  }, []);
+
+  const handleLabelSelect = useCallback(
+    (labelId) => {
+      dispatch(entryActions.addLabelToCard(labelId, cardId));
+    },
+    [cardId, dispatch],
+  );
+
+  const handleLabelDeselect = useCallback(
+    (labelId) => {
+      dispatch(entryActions.removeLabelFromCard(labelId, cardId));
+    },
+    [cardId, dispatch],
+  );
+
+  const LabelsPopup = usePopup(LabelsStep);
+
+  const showLabelPlaceholder = labelIds.length === 0 && withLabelPlaceholder && canEditLabels;
 
   const coverUrl = useSelector((state) => {
     const attachment = selectAttachmentById(state, card.coverAttachmentId);
@@ -80,15 +118,47 @@ const StoryContent = React.memo(({ cardId }) => {
         </div>
       )}
       <div className={styles.wrapper}>
-        {labelIds.length > 0 && (
-          <span className={styles.labels}>
-            {labelIds.map((labelId) => (
-              <span key={labelId} className={classNames(styles.attachment, styles.attachmentLeft)}>
-                <LabelChip id={labelId} size="tiny" />
-              </span>
-            ))}
-          </span>
-        )}
+        {(labelIds.length > 0 || showLabelPlaceholder) &&
+          (canEditLabels ? (
+            <LabelsPopup
+              currentIds={labelIds}
+              cardId={cardId}
+              onSelect={handleLabelSelect}
+              onDeselect={handleLabelDeselect}
+            >
+              <button
+                type="button"
+                onClick={handleLabelsButtonClick}
+                className={styles.labelsButton}
+              >
+                <span className={styles.labels}>
+                  {labelIds.length > 0 ? (
+                    labelIds.map((labelId) => (
+                      <span
+                        key={labelId}
+                        className={classNames(styles.attachment, styles.attachmentLeft)}
+                      >
+                        <LabelChip id={labelId} size="tiny" />
+                      </span>
+                    ))
+                  ) : (
+                    <span className={styles.labelsPlaceholder} />
+                  )}
+                </span>
+              </button>
+            </LabelsPopup>
+          ) : (
+            <span className={styles.labels}>
+              {labelIds.map((labelId) => (
+                <span
+                  key={labelId}
+                  className={classNames(styles.attachment, styles.attachmentLeft)}
+                >
+                  <LabelChip id={labelId} size="tiny" />
+                </span>
+              ))}
+            </span>
+          ))}
         {customFieldValueIds.length > 0 && (
           <span className={classNames(styles.labels)}>
             {customFieldValueIds.map((customFieldValueId) => (

--- a/client/src/components/cards/Card/StoryContent.module.scss
+++ b/client/src/components/cards/Card/StoryContent.module.scss
@@ -64,6 +64,34 @@
     overflow: hidden;
   }
 
+  .labelsButton {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    display: block;
+    margin: 0 0 4px 0;
+    max-width: 100%;
+    outline: none;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+  }
+
+  .labelsPlaceholder {
+    background: rgba(9, 30, 66, 0.04);
+    border-radius: 3px;
+    display: inline-block;
+    height: 16px;
+    margin: 0 0 6px 0;
+    min-width: 40px;
+    transition: background 0.2s ease;
+    vertical-align: top;
+
+    &:hover {
+      background: rgba(9, 30, 66, 0.08);
+    }
+  }
+
   .name {
     color: #17394d;
     font-size: 16px;

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -175,6 +175,7 @@ export default {
       description: 'Description',
       display: 'Display',
       displayCardAges: 'Display card ages',
+      displayLabelPlaceholderOnUnlabeledCards: 'Display label placeholder on unlabeled cards',
       dropFileToUpload: 'Drop file to upload',
       dueDate_title: 'Due Date',
       dynamicAndUnevenlySpacedLayout: 'Dynamic and unevenly spaced layout.',

--- a/server/api/controllers/boards/update.js
+++ b/server/api/controllers/boards/update.js
@@ -63,6 +63,10 @@
  *                 type: boolean
  *                 description: Whether to expand task lists by default
  *                 example: false
+ *               displayLabelPlaceholderOnUnlabeledCards:
+ *                 type: boolean
+ *                 description: Whether to display a clickable label placeholder on cards without labels
+ *                 example: false
  *               isSubscribed:
  *                 type: boolean
  *                 description: Whether the current user is subscribed to the board
@@ -130,6 +134,9 @@ module.exports = {
     expandTaskListsByDefault: {
       type: 'boolean',
     },
+    displayLabelPlaceholderOnUnlabeledCards: {
+      type: 'boolean',
+    },
     isSubscribed: {
       type: 'boolean',
     },
@@ -169,6 +176,7 @@ module.exports = {
         'alwaysDisplayCardCreator',
         'displayCardAges',
         'expandTaskListsByDefault',
+        'displayLabelPlaceholderOnUnlabeledCards',
       );
     }
     if (isBoardMember) {
@@ -188,6 +196,7 @@ module.exports = {
       'alwaysDisplayCardCreator',
       'displayCardAges',
       'expandTaskListsByDefault',
+      'displayLabelPlaceholderOnUnlabeledCards',
       'isSubscribed',
     ]);
 

--- a/server/api/models/Board.js
+++ b/server/api/models/Board.js
@@ -27,6 +27,7 @@
  *         - alwaysDisplayCardCreator
  *         - displayCardAges
  *         - expandTaskListsByDefault
+ *         - displayLabelPlaceholderOnUnlabeledCards
  *         - createdAt
  *         - updatedAt
  *       properties:
@@ -77,6 +78,11 @@
  *           type: boolean
  *           default: false
  *           description: Whether to expand task lists by default
+ *           example: false
+ *         displayLabelPlaceholderOnUnlabeledCards:
+ *           type: boolean
+ *           default: false
+ *           description: Whether to display a clickable label placeholder on cards without labels
  *           example: false
  *         createdAt:
  *           type: string
@@ -152,6 +158,11 @@ module.exports = {
       type: 'boolean',
       defaultsTo: false,
       columnName: 'expand_task_lists_by_default',
+    },
+    displayLabelPlaceholderOnUnlabeledCards: {
+      type: 'boolean',
+      defaultsTo: false,
+      columnName: 'display_label_placeholder_on_unlabeled_cards',
     },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗

--- a/server/db/migrations/20260503000000_add_ability_to_display_label_placeholder_on_unlabeled_cards.js
+++ b/server/db/migrations/20260503000000_add_ability_to_display_label_placeholder_on_unlabeled_cards.js
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+module.exports.up = async (knex) => {
+  await knex.schema.alterTable('board', (table) => {
+    table.boolean('display_label_placeholder_on_unlabeled_cards').notNullable().defaultTo(false);
+  });
+
+  return knex.schema.alterTable('board', (table) => {
+    table.boolean('display_label_placeholder_on_unlabeled_cards').notNullable().alter();
+  });
+};
+
+module.exports.down = (knex) =>
+  knex.schema.alterTable('board', (table) => {
+    table.dropColumn('display_label_placeholder_on_unlabeled_cards');
+  });


### PR DESCRIPTION
## Summary

Implements the feature requested in #1626: a one-click way to add or edit labels on a card without opening the card modal.

- Wraps the existing label strip on each card in a popup trigger that opens the same label selector (`LabelsStep`) used by the card modal. A click on any label chip — or on the strip as a whole — opens the popup directly. Selecting/deselecting a label updates the card immediately.
- Adds a new board-level boolean setting **\"Display label placeholder on unlabeled cards\"** (Board Settings → Preferences → Others, off by default). When on, cards that don't have labels show a small clickable placeholder strip in the same slot, so the click target is always available and boards stay visually aligned. When off, behavior on unlabeled cards is unchanged.
- The label region uses `event.stopPropagation()` so clicking it does not also open the card modal. Clicks elsewhere on the card behave exactly as before.
- Permission-aware: the popup trigger and the placeholder are only rendered for users with the EDITOR role on the board (and the list must not be Archive/Trash). Viewers see the labels as plain chips with no popup and no placeholder, matching the rest of the read-only UX.
- Applied consistently across all three card content variants on the board: Project (Kanban/Grid), Story, and the inline rows used by the List view.

## Implementation notes

**Server**
- New board attribute `displayLabelPlaceholderOnUnlabeledCards` (boolean, default `false`) in `server/api/models/Board.js`, plus the corresponding swagger schema entries.
- `server/api/controllers/boards/update.js`: added the field to the input schema, the project-manager-permitted keys list, the `_.pick` whitelist, and the swagger request body.
- New migration `server/db/migrations/20260503000000_add_ability_to_display_label_placeholder_on_unlabeled_cards.js` adding the `display_label_placeholder_on_unlabeled_cards` column to `board` (NOT NULL, default `false`), mirroring the structure of the existing `display_card_ages` migration.

**Client**
- `BoardSettingsModal/PreferencesPane/Others.jsx`: added the new toggle alongside the existing ones; uses the same generic `entryActions.updateBoard` dispatcher, so no new redux/saga wiring is needed.
- `locales/en-US/core.js`: new string `displayLabelPlaceholderOnUnlabeledCards`.
- `cards/Card/ProjectContent.jsx`, `StoryContent.jsx`, `InlineContent.jsx`: read the new flag from the current board, derive `canEditLabels` (re-using the same role check used elsewhere in the file), and wrap the labels strip in a `LabelsPopup = usePopup(LabelsStep)` trigger. When `labelIds.length === 0 && displayLabelPlaceholderOnUnlabeledCards && canEditLabels`, render an empty `<span class=\"labelsPlaceholder\">` inside the trigger button so the click target is always present.
- Matching SCSS additions in each `*.module.scss` for `.labelsButton` (resets the wrapping `<button>`), `.labelsButtonFull` (block layout when the card already has other content), and `.labelsPlaceholder` (subtle background that highlights on hover).

<img width="270" height="144" alt="image" src="https://github.com/user-attachments/assets/219143d7-421f-4c01-95b1-de13c8d6303a" />


## Test plan

- [x] Migration runs cleanly (`knex migrate:latest`) and adds the new column.
- [x] Toggle appears in Board Settings → Preferences → Others and persists across reloads.
- [x] Card with labels (Kanban Project view): clicking a chip opens the label picker; selecting/deselecting updates the card; the card modal does **not** open.
- [x] Card without labels, toggle ON: placeholder strip appears, clicking it opens the label picker, selecting a label replaces the placeholder with the chip.
- [x] Card without labels, toggle OFF: no placeholder, behavior unchanged.
- [x] Story-type cards: same behavior as Project cards.
- [x] List view (`InlineContent`): label region is clickable, placeholder appears when toggle is on.
- [ ] Viewer (non-editor) on the board: label area is non-interactive, no placeholder, no popup.
- [x] Other clicks on the card (name, icons, empty area) still open the card modal.