### PR TITLE
feat: grant project access from OIDC group claims (#1621)

### DIFF
--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -13,6 +13,7 @@ import webhooks from './webhooks';
 import users from './users';
 import projects from './projects';
 import projectManagers from './project-managers';
+import projectGroupMappings from './project-group-mappings';
 import backgroundImages from './background-images';
 import baseCustomFieldGroups from './base-custom-field-groups';
 import boards from './boards';
@@ -44,6 +45,7 @@ export default {
   ...users,
   ...projects,
   ...projectManagers,
+  ...projectGroupMappings,
   ...backgroundImages,
   ...baseCustomFieldGroups,
   ...boards,

--- a/client/src/api/project-group-mappings.js
+++ b/client/src/api/project-group-mappings.js
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import socket from './socket';
+
+/* Actions */
+
+const getProjectGroupMappings = (headers) =>
+  socket.get('/project-group-mappings', undefined, headers);
+
+const createProjectGroupMapping = (data, headers) =>
+  socket.post('/project-group-mappings', data, headers);
+
+const deleteProjectGroupMapping = (id, headers) =>
+  socket.delete(`/project-group-mappings/${id}`, undefined, headers);
+
+export default {
+  getProjectGroupMappings,
+  createProjectGroupMapping,
+  deleteProjectGroupMapping,
+};

--- a/client/src/components/common/AdministrationModal/AdministrationModal.jsx
+++ b/client/src/components/common/AdministrationModal/AdministrationModal.jsx
@@ -15,11 +15,13 @@ import { useClosableModal } from '../../../hooks';
 import UsersPane from './UsersPane';
 import SmtpPane from './SmtpPane';
 import WebhooksPane from './WebhooksPane';
+import ProjectGroupMappingsPane from './ProjectGroupMappingsPane';
 
 import styles from './AdministrationModal.module.scss';
 
 const AdministrationModal = React.memo(() => {
   const config = useSelector(selectors.selectConfig);
+  const oidcBootstrap = useSelector(selectors.selectOidcBootstrap);
 
   const dispatch = useDispatch();
   const [t] = useTranslation();
@@ -57,6 +59,14 @@ const AdministrationModal = React.memo(() => {
     }),
     render: () => <WebhooksPane />,
   });
+  if (oidcBootstrap) {
+    panes.push({
+      menuItem: t('common.oidcGroupProjectAccess', {
+        context: 'title',
+      }),
+      render: () => <ProjectGroupMappingsPane />,
+    });
+  }
 
   const isUsersPaneActive = activeTabIndex === 0;
 

--- a/client/src/components/common/AdministrationModal/ProjectGroupMappingsPane.jsx
+++ b/client/src/components/common/AdministrationModal/ProjectGroupMappingsPane.jsx
@@ -1,0 +1,168 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { Button, Dropdown, Form, Header, Icon, Input, Tab } from 'semantic-ui-react';
+
+import api from '../../../api';
+import selectors from '../../../selectors';
+
+import styles from './ProjectGroupMappingsPane.module.scss';
+
+const ProjectGroupMappingsPane = React.memo(() => {
+  const [t] = useTranslation();
+  const projects = useSelector(selectors.selectAllProjects);
+
+  const [items, setItems] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [groupName, setGroupName] = useState('');
+  const [projectId, setProjectId] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const projectsById = useMemo(() => {
+    const map = new Map();
+    projects.forEach((p) => map.set(p.id, p));
+    return map;
+  }, [projects]);
+
+  const projectOptions = useMemo(
+    () =>
+      projects
+        .map((p) => ({ key: p.id, value: p.id, text: p.name }))
+        .sort((a, b) => a.text.localeCompare(b.text)),
+    [projects],
+  );
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const { items: result } = await api.getProjectGroupMappings();
+      setItems(result);
+      setError(null);
+    } catch (err) {
+      setError(err.message || String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+
+      const trimmed = groupName.trim();
+      if (!trimmed || !projectId) {
+        return;
+      }
+
+      setIsSubmitting(true);
+      try {
+        const { item } = await api.createProjectGroupMapping({
+          groupName: trimmed,
+          projectId,
+        });
+        setItems((prev) => [...prev, item]);
+        setGroupName('');
+        setProjectId(null);
+        setError(null);
+      } catch (err) {
+        setError(err.message || String(err));
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [groupName, projectId],
+  );
+
+  const handleDelete = useCallback(async (id) => {
+    try {
+      await api.deleteProjectGroupMapping(id);
+      setItems((prev) => prev.filter((m) => m.id !== id));
+      setError(null);
+    } catch (err) {
+      setError(err.message || String(err));
+    }
+  }, []);
+
+  return (
+    <Tab.Pane attached={false} className={styles.wrapper}>
+      <Header as="h3">{t('common.oidcGroupProjectAccess', { context: 'title' })}</Header>
+      <p>{t('common.oidcGroupProjectAccessHint')}</p>
+
+      <Form onSubmit={handleSubmit} className={styles.form}>
+        <Form.Group>
+          <Form.Field width={6}>
+            <Input
+              fluid
+              placeholder={t('common.groupName')}
+              value={groupName}
+              onChange={(_, { value }) => setGroupName(value)}
+            />
+          </Form.Field>
+          <Form.Field width={8}>
+            <Dropdown
+              selection
+              search
+              fluid
+              placeholder={t('common.selectProject')}
+              options={projectOptions}
+              value={projectId}
+              onChange={(_, { value }) => setProjectId(value)}
+            />
+          </Form.Field>
+          <Form.Field width={2}>
+            <Button
+              primary
+              fluid
+              type="submit"
+              loading={isSubmitting}
+              disabled={isSubmitting || !groupName.trim() || !projectId}
+            >
+              {t('action.add')}
+            </Button>
+          </Form.Field>
+        </Form.Group>
+      </Form>
+
+      {error && <div className={styles.error}>{error}</div>}
+
+      {isLoading && <div className={styles.empty}>{t('common.loading')}…</div>}
+      {!isLoading && items.length === 0 && (
+        <div className={styles.empty}>{t('common.noMappingsConfigured')}</div>
+      )}
+      {!isLoading &&
+        items.length > 0 &&
+        items.map((mapping) => {
+          const project = projectsById.get(mapping.projectId);
+          return (
+            <div key={mapping.id} className={styles.row}>
+              <span className={styles.group}>{mapping.groupName}</span>
+              <span className={styles.arrow}>→</span>
+              <span className={styles.project}>
+                {project ? project.name : `#${mapping.projectId}`}
+              </span>
+              <Button
+                icon
+                size="small"
+                onClick={() => handleDelete(mapping.id)}
+                aria-label={t('action.delete')}
+              >
+                <Icon name="trash" />
+              </Button>
+            </div>
+          );
+        })}
+    </Tab.Pane>
+  );
+});
+
+export default ProjectGroupMappingsPane;

--- a/client/src/components/common/AdministrationModal/ProjectGroupMappingsPane.module.scss
+++ b/client/src/components/common/AdministrationModal/ProjectGroupMappingsPane.module.scss
@@ -1,0 +1,46 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+:global(#app) {
+  .wrapper {
+    border: none;
+    box-shadow: none;
+  }
+
+  .form {
+    margin-bottom: 16px;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  }
+
+  .group {
+    flex: 1;
+    font-weight: 600;
+  }
+
+  .arrow {
+    opacity: 0.5;
+  }
+
+  .project {
+    flex: 2;
+  }
+
+  .empty {
+    opacity: 0.6;
+    padding: 12px 0;
+  }
+
+  .error {
+    color: #db2828;
+    margin-top: 8px;
+  }
+}

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -370,6 +370,13 @@ export default {
       viewers: 'Viewers',
       visualTaskManagementWithLists: 'Visual task management with lists.',
       webhooks: 'Webhooks',
+      oidcGroupProjectAccess: 'OIDC group access',
+      oidcGroupProjectAccess_title: 'OIDC group access',
+      oidcGroupProjectAccessHint:
+        'Map an OIDC group claim to a project. Users with that group are automatically granted project-manager access on their next OIDC login. Removing access from a group revokes it on the next login as well.',
+      groupName: 'Group name',
+      noMappingsConfigured: 'No mappings configured.',
+      loading: 'Loading',
       whatsNew_title: "What's New",
       withoutBaseGroup: 'Without base group',
       writeComment: 'Write a comment...',

--- a/client/src/selectors/projects.js
+++ b/client/src/selectors/projects.js
@@ -27,6 +27,12 @@ export const makeSelectProjectById = () =>
 
 export const selectProjectById = makeSelectProjectById();
 
+export const selectAllProjects = createSelector(orm, ({ Project }) =>
+  Project.all()
+    .toRefArray()
+    .filter(({ id }) => !isLocalId(id)),
+);
+
 export const makeSelectBoardIdsByProjectId = () =>
   createSelector(
     orm,
@@ -313,6 +319,7 @@ export const selectIsCurrentUserManagerForCurrentProject = createSelector(
 export default {
   makeSelectProjectById,
   selectProjectById,
+  selectAllProjects,
   makeSelectBoardIdsByProjectId,
   selectBoardIdsByProjectId,
   makeSelectFirstBoardIdByProjectId,

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -72,6 +72,9 @@ SECRET_KEY=notsecretkey
 # OIDC_ROLES_ATTRIBUTE=groups
 # OIDC_IGNORE_USERNAME=true
 # OIDC_IGNORE_ROLES=true
+# Set to true to disable automatic project-manager assignment from OIDC group
+# claims (project_group_mapping table). Defaults to false (sync runs on login).
+# OIDC_IGNORE_GROUP_PROJECT_ACCESS=true
 # OIDC_ENFORCED=true
 # OIDC_TIMEOUT=3500
 # OIDC_DEBUG=true

--- a/server/api/controllers/project-group-mappings/create.js
+++ b/server/api/controllers/project-group-mappings/create.js
@@ -1,0 +1,124 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+/**
+ * @swagger
+ * /project-group-mappings:
+ *   post:
+ *     summary: Create a project group mapping
+ *     description: Maps an OIDC group name to a project. Users with the group claim
+ *                  are granted project-manager access on next OIDC login. Admin only.
+ *     tags:
+ *       - Project Group Mappings
+ *     operationId: createProjectGroupMapping
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - groupName
+ *               - projectId
+ *             properties:
+ *               groupName:
+ *                 type: string
+ *                 example: "developers"
+ *               projectId:
+ *                 type: string
+ *                 example: "1357158568008091265"
+ *     responses:
+ *       200:
+ *         description: Mapping created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - item
+ *               properties:
+ *                 item:
+ *                   $ref: '#/components/schemas/ProjectGroupMapping'
+ *       400:
+ *         $ref: '#/components/responses/ValidationError'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ *       409:
+ *         $ref: '#/components/responses/Conflict'
+ */
+
+const { idInput } = require('../../../utils/inputs');
+
+const Errors = {
+  NOT_ENOUGH_RIGHTS: {
+    notEnoughRights: 'Not enough rights',
+  },
+  PROJECT_NOT_FOUND: {
+    projectNotFound: 'Project not found',
+  },
+  MAPPING_ALREADY_EXISTS: {
+    mappingAlreadyExists: 'Mapping already exists',
+  },
+};
+
+module.exports = {
+  inputs: {
+    groupName: {
+      type: 'string',
+      required: true,
+      minLength: 1,
+      maxLength: 256,
+    },
+    projectId: {
+      ...idInput,
+      required: true,
+    },
+  },
+
+  exits: {
+    notEnoughRights: {
+      responseType: 'forbidden',
+    },
+    projectNotFound: {
+      responseType: 'notFound',
+    },
+    mappingAlreadyExists: {
+      responseType: 'conflict',
+    },
+  },
+
+  async fn(inputs) {
+    const { currentUser } = this.req;
+
+    if (currentUser.role !== User.Roles.ADMIN) {
+      throw Errors.NOT_ENOUGH_RIGHTS;
+    }
+
+    const project = await Project.qm.getOneById(inputs.projectId);
+
+    if (!project) {
+      throw Errors.PROJECT_NOT_FOUND;
+    }
+
+    const mapping = await sails.helpers.projectGroupMappings.createOne
+      .with({
+        values: {
+          groupName: inputs.groupName.trim(),
+          project,
+        },
+        actorUser: currentUser,
+        request: this.req,
+      })
+      .intercept('mappingAlreadyExists', () => Errors.MAPPING_ALREADY_EXISTS);
+
+    return {
+      item: mapping,
+    };
+  },
+};

--- a/server/api/controllers/project-group-mappings/delete.js
+++ b/server/api/controllers/project-group-mappings/delete.js
@@ -1,0 +1,96 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+/**
+ * @swagger
+ * /project-group-mappings/{id}:
+ *   delete:
+ *     summary: Delete a project group mapping
+ *     description: Removes an OIDC group → project mapping. Existing project_manager
+ *                  rows previously created from this mapping are NOT removed
+ *                  immediately; they will be reconciled on each user's next OIDC login.
+ *                  Admin only.
+ *     tags:
+ *       - Project Group Mappings
+ *     operationId: deleteProjectGroupMapping
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: "1357158568008091264"
+ *     responses:
+ *       200:
+ *         description: Mapping deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - item
+ *               properties:
+ *                 item:
+ *                   $ref: '#/components/schemas/ProjectGroupMapping'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ */
+
+const { idInput } = require('../../../utils/inputs');
+
+const Errors = {
+  NOT_ENOUGH_RIGHTS: {
+    notEnoughRights: 'Not enough rights',
+  },
+  MAPPING_NOT_FOUND: {
+    mappingNotFound: 'Mapping not found',
+  },
+};
+
+module.exports = {
+  inputs: {
+    id: {
+      ...idInput,
+      required: true,
+    },
+  },
+
+  exits: {
+    notEnoughRights: {
+      responseType: 'forbidden',
+    },
+    mappingNotFound: {
+      responseType: 'notFound',
+    },
+  },
+
+  async fn(inputs) {
+    const { currentUser } = this.req;
+
+    if (currentUser.role !== User.Roles.ADMIN) {
+      throw Errors.NOT_ENOUGH_RIGHTS;
+    }
+
+    const mapping = await ProjectGroupMapping.qm.getOneById(inputs.id);
+
+    if (!mapping) {
+      throw Errors.MAPPING_NOT_FOUND;
+    }
+
+    const deleted = await sails.helpers.projectGroupMappings.deleteOne.with({
+      record: mapping,
+      actorUser: currentUser,
+      request: this.req,
+    });
+
+    return {
+      item: deleted,
+    };
+  },
+};

--- a/server/api/controllers/project-group-mappings/index.js
+++ b/server/api/controllers/project-group-mappings/index.js
@@ -1,0 +1,61 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+/**
+ * @swagger
+ * /project-group-mappings:
+ *   get:
+ *     summary: List OIDC group → project access mappings
+ *     description: Returns all configured OIDC group → project mappings. Admin only.
+ *     tags:
+ *       - Project Group Mappings
+ *     operationId: getProjectGroupMappings
+ *     responses:
+ *       200:
+ *         description: Mappings retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - items
+ *               properties:
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/ProjectGroupMapping'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ */
+
+const Errors = {
+  NOT_ENOUGH_RIGHTS: {
+    notEnoughRights: 'Not enough rights',
+  },
+};
+
+module.exports = {
+  exits: {
+    notEnoughRights: {
+      responseType: 'forbidden',
+    },
+  },
+
+  async fn() {
+    const { currentUser } = this.req;
+
+    if (currentUser.role !== User.Roles.ADMIN) {
+      throw Errors.NOT_ENOUGH_RIGHTS;
+    }
+
+    const mappings = await sails.helpers.projectGroupMappings.getAll();
+
+    return {
+      items: mappings,
+    };
+  },
+};

--- a/server/api/helpers/project-group-mappings/create-one.js
+++ b/server/api/helpers/project-group-mappings/create-one.js
@@ -1,0 +1,60 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+module.exports = {
+  inputs: {
+    values: {
+      type: 'ref',
+      required: true,
+    },
+    actorUser: {
+      type: 'ref',
+      required: true,
+    },
+    request: {
+      type: 'ref',
+    },
+  },
+
+  exits: {
+    mappingAlreadyExists: {},
+  },
+
+  async fn(inputs) {
+    const { values } = inputs;
+
+    let mapping;
+    try {
+      mapping = await ProjectGroupMapping.qm.createOne({
+        groupName: values.groupName,
+        projectId: values.project.id,
+      });
+    } catch (error) {
+      if (error.code === 'E_UNIQUE') {
+        throw 'mappingAlreadyExists';
+      }
+
+      throw error;
+    }
+
+    const adminUsers = await User.qm.getAll({
+      roleOrRoles: User.Roles.ADMIN,
+      isDeactivated: false,
+    });
+
+    adminUsers.forEach((adminUser) => {
+      sails.sockets.broadcast(
+        `user:${adminUser.id}`,
+        'projectGroupMappingCreate',
+        {
+          item: mapping,
+        },
+        inputs.request,
+      );
+    });
+
+    return mapping;
+  },
+};

--- a/server/api/helpers/project-group-mappings/delete-one.js
+++ b/server/api/helpers/project-group-mappings/delete-one.js
@@ -1,0 +1,44 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+module.exports = {
+  inputs: {
+    record: {
+      type: 'ref',
+      required: true,
+    },
+    actorUser: {
+      type: 'ref',
+      required: true,
+    },
+    request: {
+      type: 'ref',
+    },
+  },
+
+  async fn(inputs) {
+    const mapping = await ProjectGroupMapping.qm.deleteOne(inputs.record.id);
+
+    if (mapping) {
+      const adminUsers = await User.qm.getAll({
+        roleOrRoles: User.Roles.ADMIN,
+        isDeactivated: false,
+      });
+
+      adminUsers.forEach((adminUser) => {
+        sails.sockets.broadcast(
+          `user:${adminUser.id}`,
+          'projectGroupMappingDelete',
+          {
+            item: mapping,
+          },
+          inputs.request,
+        );
+      });
+    }
+
+    return mapping;
+  },
+};

--- a/server/api/helpers/project-group-mappings/get-all.js
+++ b/server/api/helpers/project-group-mappings/get-all.js
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+module.exports = {
+  async fn() {
+    return ProjectGroupMapping.qm.getAll();
+  },
+};

--- a/server/api/helpers/project-managers/create-one.js
+++ b/server/api/helpers/project-managers/create-one.js
@@ -43,6 +43,8 @@ module.exports = {
       projectManager = await ProjectManager.qm.createOne({
         projectId: values.project.id,
         userId: values.user.id,
+        isFromGroupSync: values.isFromGroupSync === true,
+        sourceGroupName: values.sourceGroupName || null,
       });
     } catch (error) {
       if (error.code === 'E_UNIQUE') {

--- a/server/api/helpers/users/get-or-create-one-with-oidc.js
+++ b/server/api/helpers/users/get-or-create-one-with-oidc.js
@@ -195,6 +195,21 @@ module.exports = {
       }
     }
 
+    if (!sails.config.custom.oidcIgnoreGroupProjectAccess) {
+      const claimsGroups = _.get(claims, sails.config.custom.oidcRolesAttribute);
+      const groupNames = Array.isArray(claimsGroups) ? claimsGroups : [];
+
+      try {
+        await sails.helpers.users.syncOidcGroupProjectAccess.with({
+          user,
+          groupNames,
+          actorUser: User.OIDC,
+        });
+      } catch (error) {
+        sails.log.warn(`OIDC group project-access sync failed for user ${user.id}: ${error}`);
+      }
+    }
+
     return user;
   },
 };

--- a/server/api/helpers/users/sync-oidc-group-project-access.js
+++ b/server/api/helpers/users/sync-oidc-group-project-access.js
@@ -1,0 +1,101 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+module.exports = {
+  inputs: {
+    user: {
+      type: 'ref',
+      required: true,
+    },
+    groupNames: {
+      type: 'ref',
+      required: true,
+    },
+    actorUser: {
+      type: 'ref',
+      required: true,
+    },
+  },
+
+  async fn(inputs) {
+    const { user, actorUser } = inputs;
+    const groupNames = Array.isArray(inputs.groupNames) ? inputs.groupNames : [];
+
+    const desiredByProjectId = new Map();
+    if (groupNames.length > 0) {
+      const mappings = await ProjectGroupMapping.qm.getByGroupNames(groupNames);
+      mappings.forEach((mapping) => {
+        if (!desiredByProjectId.has(mapping.projectId)) {
+          desiredByProjectId.set(mapping.projectId, mapping.groupName);
+        }
+      });
+    }
+
+    const existing = await ProjectManager.qm.getByUserIdAndIsFromGroupSync(user.id, true);
+    const existingByProjectId = new Map(existing.map((row) => [row.projectId, row]));
+
+    const projectIdsToAdd = [...desiredByProjectId.keys()].filter(
+      (projectId) => !existingByProjectId.has(projectId),
+    );
+    const rowsToRemove = existing.filter((row) => !desiredByProjectId.has(row.projectId));
+
+    const webhooks = await Webhook.qm.getAll();
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const projectId of projectIdsToAdd) {
+      // Skip if a non-group manual assignment already exists for this pair —
+      // we must not duplicate or clobber it.
+      // eslint-disable-next-line no-await-in-loop
+      const existingAny = await ProjectManager.qm.getOneByProjectIdAndUserId(projectId, user.id);
+      if (!existingAny) {
+        // eslint-disable-next-line no-await-in-loop
+        const project = await Project.qm.getOneById(projectId);
+        if (project) {
+          try {
+            // eslint-disable-next-line no-await-in-loop
+            await sails.helpers.projectManagers.createOne.with({
+              webhooks,
+              values: {
+                project,
+                user,
+                isFromGroupSync: true,
+                sourceGroupName: desiredByProjectId.get(projectId),
+              },
+              actorUser,
+            });
+          } catch (error) {
+            sails.log.warn(
+              `OIDC group sync: failed to grant project ${projectId} to user ${user.id}: ${error}`,
+            );
+          }
+        }
+      }
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const row of rowsToRemove) {
+      // eslint-disable-next-line no-await-in-loop
+      const project = await Project.qm.getOneById(row.projectId);
+      if (!project) {
+        // eslint-disable-next-line no-await-in-loop
+        await ProjectManager.qm.deleteOne(row.id);
+      } else {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await sails.helpers.projectManagers.deleteOne.with({
+            record: row,
+            user,
+            project,
+            actorUser,
+          });
+        } catch (error) {
+          sails.log.warn(
+            `OIDC group sync: failed to revoke project ${row.projectId} from user ${user.id}: ${error}`,
+          );
+        }
+      }
+    }
+  },
+};

--- a/server/api/hooks/query-methods/models/ProjectGroupMapping.js
+++ b/server/api/hooks/query-methods/models/ProjectGroupMapping.js
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const defaultFind = (criteria) => ProjectGroupMapping.find(criteria).sort('id');
+
+/* Query methods */
+
+const createOne = (values) => ProjectGroupMapping.create({ ...values }).fetch();
+
+const getAll = () => defaultFind({});
+
+const getByIds = (ids) => defaultFind(ids);
+
+const getOneById = (id) => ProjectGroupMapping.findOne({ id });
+
+const getByGroupNames = (groupNames) =>
+  defaultFind({
+    groupName: groupNames,
+  });
+
+const getByProjectId = (projectId) =>
+  defaultFind({
+    projectId,
+  });
+
+const getOneByGroupNameAndProjectId = (groupName, projectId) =>
+  ProjectGroupMapping.findOne({
+    groupName,
+    projectId,
+  });
+
+const deleteOne = (criteria) => ProjectGroupMapping.destroyOne(criteria);
+
+module.exports = {
+  createOne,
+  getAll,
+  getByIds,
+  getOneById,
+  getByGroupNames,
+  getByProjectId,
+  getOneByGroupNameAndProjectId,
+  deleteOne,
+};

--- a/server/api/hooks/query-methods/models/ProjectManager.js
+++ b/server/api/hooks/query-methods/models/ProjectManager.js
@@ -44,6 +44,12 @@ const getByUserId = (userId) =>
     userId,
   });
 
+const getByUserIdAndIsFromGroupSync = (userId, isFromGroupSync) =>
+  defaultFind({
+    userId,
+    isFromGroupSync,
+  });
+
 const getOneById = (id, { projectId } = {}) => {
   const criteria = {
     id,
@@ -73,6 +79,7 @@ module.exports = {
   getByProjectId,
   getByProjectIds,
   getByUserId,
+  getByUserIdAndIsFromGroupSync,
   getOneById,
   getOneByProjectIdAndUserId,
   deleteOne,

--- a/server/api/models/ProjectGroupMapping.js
+++ b/server/api/models/ProjectGroupMapping.js
@@ -4,9 +4,10 @@
  */
 
 /**
- * ProjectManager.js
+ * ProjectGroupMapping.js
  *
- * @description :: A model definition represents a database table/collection.
+ * @description :: Maps an OIDC group name to a project. Users belonging to the
+ *                 group are granted project-manager access on OIDC login.
  * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
  */
 
@@ -14,38 +15,36 @@
  * @swagger
  * components:
  *   schemas:
- *     ProjectManager:
+ *     ProjectGroupMapping:
  *       type: object
  *       required:
  *         - id
+ *         - groupName
  *         - projectId
- *         - userId
  *         - createdAt
  *         - updatedAt
  *       properties:
  *         id:
  *           type: string
- *           description: Unique identifier for the project manager
+ *           description: Unique identifier for the mapping
  *           example: "1357158568008091264"
+ *         groupName:
+ *           type: string
+ *           description: OIDC group name (as it appears in the configured roles claim)
+ *           example: "developers"
  *         projectId:
  *           type: string
- *           description: ID of the project the manager is associated with
+ *           description: ID of the project users in the group are granted access to
  *           example: "1357158568008091265"
- *         userId:
- *           type: string
- *           description: ID of the user who is assigned as project manager
- *           example: "1357158568008091266"
  *         createdAt:
  *           type: string
  *           format: date-time
  *           nullable: true
- *           description: When the project manager was created
  *           example: 2024-01-01T00:00:00.000Z
  *         updatedAt:
  *           type: string
  *           format: date-time
  *           nullable: true
- *           description: When the project manager was last updated
  *           example: 2024-01-01T00:00:00.000Z
  */
 
@@ -55,20 +54,15 @@ module.exports = {
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
 
+    groupName: {
+      type: 'string',
+      required: true,
+      columnName: 'group_name',
+    },
+
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗
     //  ╚═╝╩ ╩╚═╝╚═╝═╩╝╚═╝
-
-    isFromGroupSync: {
-      type: 'boolean',
-      defaultsTo: false,
-      columnName: 'is_from_group_sync',
-    },
-    sourceGroupName: {
-      type: 'string',
-      allowNull: true,
-      columnName: 'source_group_name',
-    },
 
     //  ╔═╗╔═╗╔═╗╔═╗╔═╗╦╔═╗╔╦╗╦╔═╗╔╗╔╔═╗
     //  ╠═╣╚═╗╚═╗║ ║║  ║╠═╣ ║ ║║ ║║║║╚═╗
@@ -79,12 +73,7 @@ module.exports = {
       required: true,
       columnName: 'project_id',
     },
-    userId: {
-      model: 'User',
-      required: true,
-      columnName: 'user_id',
-    },
   },
 
-  tableName: 'project_manager',
+  tableName: 'project_group_mapping',
 };

--- a/server/config/custom.js
+++ b/server/config/custom.js
@@ -93,6 +93,7 @@ module.exports.custom = {
   oidcRolesAttribute: process.env.OIDC_ROLES_ATTRIBUTE || 'groups',
   oidcIgnoreUsername: process.env.OIDC_IGNORE_USERNAME === 'true',
   oidcIgnoreRoles: process.env.OIDC_IGNORE_ROLES === 'true',
+  oidcIgnoreGroupProjectAccess: process.env.OIDC_IGNORE_GROUP_PROJECT_ACCESS === 'true',
   oidcEnforced: process.env.OIDC_ENFORCED === 'true',
   oidcTimeout: envToNumber(process.env.OIDC_TIMEOUT),
   oidcDebug: process.env.OIDC_DEBUG === 'true',

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -143,6 +143,10 @@ module.exports.routes = {
   'POST /api/projects/:projectId/project-managers': 'project-managers/create',
   'DELETE /api/project-managers/:id': 'project-managers/delete',
 
+  'GET /api/project-group-mappings': 'project-group-mappings/index',
+  'POST /api/project-group-mappings': 'project-group-mappings/create',
+  'DELETE /api/project-group-mappings/:id': 'project-group-mappings/delete',
+
   'POST /api/projects/:projectId/background-images': 'background-images/create',
   'DELETE /api/background-images/:id': 'background-images/delete',
 

--- a/server/db/migrations/20260503100000_add_oidc_group_project_access.js
+++ b/server/db/migrations/20260503100000_add_oidc_group_project_access.js
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+exports.up = async (knex) => {
+  await knex.schema.createTable('project_group_mapping', (table) => {
+    table.bigInteger('id').primary().defaultTo(knex.raw('next_id()'));
+
+    table.text('group_name').notNullable();
+    table.bigInteger('project_id').notNullable();
+
+    table.timestamp('created_at', true);
+    table.timestamp('updated_at', true);
+
+    table.unique(['group_name', 'project_id']);
+    table.index('group_name');
+    table.index('project_id');
+  });
+
+  await knex.schema.alterTable('project_manager', (table) => {
+    table.boolean('is_from_group_sync').notNullable().defaultTo(false);
+    table.text('source_group_name');
+
+    table.index('is_from_group_sync');
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('project_manager', (table) => {
+    table.dropIndex('is_from_group_sync');
+    table.dropColumn('source_group_name');
+    table.dropColumn('is_from_group_sync');
+  });
+
+  await knex.schema.dropTable('project_group_mapping');
+};


### PR DESCRIPTION
## Summary

Closes #1621.

Today, OIDC group claims drive only the user's *global* role (`ADMIN` / `PROJECT_OWNER` / `BOARD_USER`). Per-project access still has to be granted manually by inserting rows into `project_manager`.

This PR lets administrators map an OIDC group name to a project so that, on every OIDC login, group membership is reconciled into `project_manager`:

- users newly in a mapped group get a `project_manager` row,
- users no longer in a mapped group lose the previously-synced row,
- rows that admins assigned manually (outside group sync) are never touched.

The behavior is opt-out via `OIDC_IGNORE_GROUP_PROJECT_ACCESS=true`.

## Why

For organizations using Authentik / Keycloak / etc. with OIDC, project access today does not scale: every new hire requires the admin to manually add them to every relevant project. Group claims are already emitted by the IdP — Planka just needs to consume them.

## What changed

### Database

New migration `20260503100000_add_oidc_group_project_access.js`:

- New table `project_group_mapping(id, group_name, project_id, ...)`, unique `(group_name, project_id)`, indexed by both columns.
- New columns on `project_manager`:
  - `is_from_group_sync` (boolean, default `false`)
  - `source_group_name` (text, nullable)
  - index on `is_from_group_sync`

These flags let the reconciliation step distinguish manual assignments from group-derived ones, so a group change never deletes a manual row.

### Server

- New model `ProjectGroupMapping` + query methods (`createOne`, `getAll`, `getByGroupNames`, `getByProjectId`, `getOneByGroupNameAndProjectId`, `deleteOne`).
- `ProjectManager` model extended with the two new attributes; new query method `getByUserIdAndIsFromGroupSync` is the basis of the reconciliation diff.
- `helpers/project-managers/create-one` accepts optional `isFromGroupSync` / `sourceGroupName` so socket broadcasts and webhooks fire identically for manual and group-derived assignments.
- New helper `helpers/users/sync-oidc-group-project-access`:
  - inputs: `user`, `groupNames`, `actorUser`,
  - reads `project_group_mapping` for those group names,
  - reads existing group-synced rows for the user,
  - adds rows for newly-desired projects (skipping any pair with an existing manual row),
  - deletes rows for projects no longer covered by the user's groups,
  - idempotent, swallows per-row failures with `sails.log.warn` to avoid blocking the login flow.
- `helpers/users/get-or-create-one-with-oidc` invokes the sync once the user is resolved (both create and update branches), gated by `OIDC_IGNORE_GROUP_PROJECT_ACCESS`, wrapped in try/catch.
- New env flag `OIDC_IGNORE_GROUP_PROJECT_ACCESS` documented in `.env.sample`, exposed via `config/custom.js`.

### Admin REST API (admin only)

- `GET /api/project-group-mappings`
- `POST /api/project-group-mappings` — body `{ groupName, projectId }`
- `DELETE /api/project-group-mappings/:id`

Routes mirror the layout of `project-managers`. Helpers/controllers broadcast `projectGroupMappingCreate` / `projectGroupMappingDelete` events to admin user rooms only.

### Client

- `api/project-group-mappings.js` registered in `api/index`.
- New selector `selectAllProjects` for the project picker.
- New self-contained `ProjectGroupMappingsPane` rendered in the Administration modal as a new "OIDC group access" tab. Visible only when OIDC is configured (gated on `selectOidcBootstrap`). Uses the REST API directly via the existing socket transport — no redux-orm wiring for now.
- i18n strings added to `en-US/core.js`.

## Configuration

| Variable                            | Default | Effect                                                                 |
| ----------------------------------- | ------- | ---------------------------------------------------------------------- |
| `OIDC_IGNORE_GROUP_PROJECT_ACCESS`  | `false` | When \`true\`, disables the sync entirely. Manual assignments untouched. |

The existing `OIDC_ROLES_ATTRIBUTE` (default `groups`) is reused — the same claim that drives global role detection is now also consumed by the project-access sync. No new claim configuration is required.

## Backwards compatibility

- Migration is additive (new table + new columns with safe defaults). Existing `project_manager` rows transparently get `is_from_group_sync = false` and remain "manual" forever.
- `OIDC_IGNORE_GROUP_PROJECT_ACCESS=true` makes this PR a no-op, preserving today's behavior exactly.
- No existing API contracts changed.

## Test plan

Manual (no automated tests added — see Caveats):

- [ ] Migration applies cleanly: `npm run db:migrate`. Verify `\d project_manager` shows the two new columns and `\d project_group_mapping` exists.
- [ ] With OIDC configured, the **OIDC group access** tab appears in the Administration modal for admins; it is hidden if OIDC is not configured.
- [ ] Create a mapping `developers → Project A` via the new pane — a row appears in `project_group_mapping`.
- [ ] Log in via OIDC as a user in group `developers`. Project A is visible; `project_manager` has a row with `is_from_group_sync = true`, `source_group_name = 'developers'`.
- [ ] Remove the user from `developers` in the IdP, log in again. Project A disappears; the corresponding `project_manager` row is gone.
- [ ] Manually add the same user as a manager via the existing UI (creates a row with `is_from_group_sync = false`). Log them in again while still out of the group — manual row is preserved.
- [ ] Delete the mapping in the admin pane — the `project_group_mapping` row is removed; existing group-derived `project_manager` rows are NOT removed immediately, they get reconciled at the affected user's next OIDC login (by design).
- [ ] Set `OIDC_IGNORE_GROUP_PROJECT_ACCESS=true`, restart, log in via OIDC: sync does not run; nothing in `project_manager` changes.
- [ ] Non-admin requests to `GET/POST/DELETE /api/project-group-mappings` return `403`.

## Caveats / follow-ups

- **No automated tests.** The repo has no live integration tests for helpers/controllers today (`server/test/integration/{helpers,controllers}` are empty); the existing manual-test conventions are followed. A follow-up could introduce a Mocha test for the reconciliation diff in `sync-oidc-group-project-access`.
- **Frontend pane is not wired into redux-orm.** Concurrent edits by another admin are not pushed live; reopening the pane refreshes the list. Full slice/saga integration is intentionally deferred.
- **Mapping deletion is not eager.** Deleting `developers → Project A` does not immediately revoke `project_manager` rows for users who were granted access via that mapping. They are reconciled on each user's next OIDC login. Documented in the PR and in the controller swagger.