### PR TITLE
feat: honor OIDC_PROXY env variable for OIDC HTTP requests

### DIFF
--- a/server/.env.sample
+++ b/server/.env.sample
@@ -74,6 +74,9 @@ SECRET_KEY=notsecretkey
 # OIDC_IGNORE_ROLES=true
 # OIDC_ENFORCED=true
 # OIDC_TIMEOUT=3500
+# Proxy used for backend OIDC HTTP calls only (issuer discovery, token exchange,
+# userinfo). Independent from OUTGOING_PROXY, which controls UI-initiated egress.
+# OIDC_PROXY=http://proxy:3128
 # OIDC_DEBUG=true
 
 # Email Notifications (https://nodemailer.com/smtp/)

--- a/server/api/hooks/oidc/index.js
+++ b/server/api/hooks/oidc/index.js
@@ -45,10 +45,20 @@ module.exports = function defineOidcHook(sails) {
       clientInitPromise = (async () => {
         sails.log.info('Initializing OIDC client');
 
+        const httpOptions = {};
         if (sails.config.custom.oidcTimeout !== null) {
-          openidClient.custom.setHttpOptionsDefaults({
-            timeout: sails.config.custom.oidcTimeout,
-          });
+          httpOptions.timeout = sails.config.custom.oidcTimeout;
+        }
+        if (sails.config.custom.oidcProxy) {
+          // eslint-disable-next-line global-require
+          const { HttpProxyAgent, HttpsProxyAgent } = require('hpagent');
+          httpOptions.agent = {
+            http: new HttpProxyAgent({ proxy: sails.config.custom.oidcProxy }),
+            https: new HttpsProxyAgent({ proxy: sails.config.custom.oidcProxy }),
+          };
+        }
+        if (Object.keys(httpOptions).length > 0) {
+          openidClient.custom.setHttpOptionsDefaults(httpOptions);
         }
 
         let issuer;

--- a/server/config/custom.js
+++ b/server/config/custom.js
@@ -95,6 +95,7 @@ module.exports.custom = {
   oidcIgnoreRoles: process.env.OIDC_IGNORE_ROLES === 'true',
   oidcEnforced: process.env.OIDC_ENFORCED === 'true',
   oidcTimeout: envToNumber(process.env.OIDC_TIMEOUT),
+  oidcProxy: process.env.OIDC_PROXY,
   oidcDebug: process.env.OIDC_DEBUG === 'true',
 
   // TODO: move client base url to environment variable?

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
         "escape-markdown": "^1.0.4",
         "file-type": "^21.3.2",
         "fs-extra": "^11.3.4",
+        "hpagent": "^1.2.0",
         "i18n-2": "^0.7.3",
         "ico-to-png": "^0.2.2",
         "istextorbinary": "^9.5.0",
@@ -5892,6 +5893,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/http-errors": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,6 +60,7 @@
     "escape-markdown": "^1.0.4",
     "file-type": "^21.3.2",
     "fs-extra": "^11.3.4",
+    "hpagent": "^1.2.0",
     "i18n-2": "^0.7.3",
     "ico-to-png": "^0.2.2",
     "istextorbinary": "^9.5.0",


### PR DESCRIPTION
Closes #1620.

  ## Problem

  When Planka is deployed in a network where direct egress is blocked and all outbound HTTPS must traverse a corporate proxy, OIDC integrations (Okta, Auth0, etc.) intermittently fail with
  errors like:

  [W] Error while initializing OIDC client: RPError: outgoing request timed out after 3500ms

  The existing `OUTGOING_PROXY` variable does not cover OIDC because:

  - `openid-client` uses Node's `http`/`https` stack via the `got` HTTP client, while `OUTGOING_PROXY` is plumbed only into undici-based `fetch()` callsites (webhooks, Apprise, favicon
  downloads, SMTP).
  - `OUTGOING_PROXY` is part of the UI security model: combined with `OUTGOING_BLOCKED_HOSTS` / `OUTGOING_BLOCKED_IPS` it prevents users from reaching internal services via UI-configurable
  URLs. Routing OIDC through that same channel would conflate a backend, operator-controlled concern (where to reach the IdP) with a user-blocking security boundary.

  The maintainer's recommendation in the issue thread was therefore to introduce a **dedicated `OIDC_PROXY`** env variable rather than reuse `OUTGOING_PROXY`.

  ## Change

  A new optional env variable `OIDC_PROXY` is added. When set, all OIDC-related backend HTTP calls (issuer discovery, token exchange, userinfo) are routed through it.

  The implementation hooks into openid-client's global HTTP defaults, so a single configuration point covers every callsite without touching individual flows:

  - `server/api/hooks/oidc/index.js` — `Issuer.discover`
  - `server/api/helpers/users/get-or-create-one-with-oidc.js` — `client.callback` / `client.oauthCallback` / `client.userinfo`
  - `server/api/controllers/access-tokens/debug-oidc.js` — same callbacks under `OIDC_DEBUG`

  Proxy support uses [`hpagent`](https://github.com/delvedor/hpagent), which provides `http.Agent` / `https.Agent` implementations compatible with the `got` library that openid-client relies
  on. (undici's `ProxyAgent` cannot be used here — it is a `fetch` dispatcher, not a Node `http` agent.)

  ## Files

  - **`server/config/custom.js`** — reads `OIDC_PROXY` into `sails.config.custom.oidcProxy`, alongside the other `oidc*` settings.
  - **`server/api/hooks/oidc/index.js`** — builds an `httpOptions` object combining `timeout` (existing) and `agent` (new) and passes it once to openid-client's `setHttpOptionsDefaults`. The
  `agent` block is created only when `OIDC_PROXY` is set, so the no-proxy code path is byte-for-byte equivalent to before.
  - **`server/package.json` / `server/package-lock.json`** — adds `hpagent ^1.2.0` as a server dependency.
  - **`server/.env.sample`** — documents `OIDC_PROXY` in the OIDC block, with a note that it is independent from `OUTGOING_PROXY` (UI-initiated egress) and applies only to backend OIDC calls.

  ## Compatibility

  - **Backwards compatible**: with `OIDC_PROXY` unset, behavior is unchanged. Existing `OUTGOING_PROXY` semantics are not modified; the two variables are independent and can be combined or
  used separately.
  - No DB migration, no API change, no client change.

  ## Out of scope

  The maintainer noted that S3 and SMTP could benefit from the same treatment. Those are intentionally not addressed here — this PR is scoped strictly to the OIDC failure reported in #1620 to
   keep the change surface minimal and easy to review. Dedicated S3/SMTP proxy variables can follow as separate PRs.

  ## Test plan

  - [x] With `OIDC_PROXY` unset and direct egress blocked: reproduce original `RPError: outgoing request timed out` from the issue.
  - [x] With `OIDC_PROXY=http://proxy:8888` and direct egress blocked: issuer discovery, token exchange, and userinfo all traverse the proxy (verified in proxy access log) and OIDC login
  succeeds.
  - [x] With `OIDC_PROXY` set but `OUTGOING_PROXY` unset: webhook / Apprise / favicon traffic does **not** go through the proxy — the two channels stay isolated.
  - [x] With `OIDC_PROXY` unset and direct egress allowed: previous behavior unchanged.
  - [x] `npm run lint` (server) passes.