### PR TITLE
fix: inherit active board filters when creating a card ()

### DIFF
--- a/client/src/sagas/core/services/cards.js
+++ b/client/src/sagas/core/services/cards.js
@@ -3,11 +3,13 @@
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
  */
 
-import { call, fork, join, put, race, select, take } from 'redux-saga/effects';
+import { all, call, fork, join, put, race, select, take } from 'redux-saga/effects';
 import toast from 'react-hot-toast';
 import { LOCATION_CHANGE_HANDLE } from '../../../lib/redux-router';
 
 import { goToBoard, goToCard } from './router';
+import { addUserToCard } from './users';
+import { addLabelToCard } from './labels';
 import request from '../request';
 import selectors from '../../../selectors';
 import actions from '../../../actions';
@@ -165,6 +167,15 @@ export function* createCard(listId, data, index, autoOpen) {
   }
 
   yield put(actions.createCard.success(localId, card));
+
+  // Inherit active board filters so the new card stays visible in the filtered view
+  const filterUserIds = yield select(selectors.selectFilterUserIdsForCurrentBoard);
+  const filterLabelIds = yield select(selectors.selectFilterLabelIdsForCurrentBoard);
+
+  yield all([
+    ...filterUserIds.map((userId) => call(addUserToCard, userId, card.id)),
+    ...filterLabelIds.map((labelId) => call(addLabelToCard, labelId, card.id)),
+  ]);
 
   if (watchForCreateCardActionTask && watchForCreateCardActionTask.isRunning()) {
     yield call(goToCard, card.id);


### PR DESCRIPTION
A card created while member/label filters were active was made without any members or labels, so the all-or-nothing filter immediately excluded it and the card vanished from the view.

After a card is created, assign the active filter users and labels to it (reusing addUserToCard/addLabelToCard) so it stays visible. No-op when no filters are active.

https://github.com/user-attachments/assets/fe2e583d-7925-4596-81bb-842bc60e7437


CLosed: #1663