### PR TITLE
feat: show card count in list header (#1664)

### DIFF
--- a/client/src/components/lists/List/List.jsx
+++ b/client/src/components/lists/List/List.jsx
@@ -226,6 +226,7 @@ const List = React.memo(({ id, index }) => {
                     />
                   )}
                   {list.name}
+                  <span className={styles.cardCount}>{cardIds.length}</span>
                 </div>
               )}
               {list.type !== ListTypes.ACTIVE && (

--- a/client/src/components/lists/List/List.module.scss
+++ b/client/src/components/lists/List/List.module.scss
@@ -155,6 +155,13 @@
     margin-right: 6px;
   }
 
+  .cardCount {
+    color: #6b808c;
+    font-size: 12px;
+    font-weight: normal;
+    margin-left: 6px;
+  }
+
   .innerWrapper {
     margin-right: 8px;
     width: 272px;


### PR DESCRIPTION
Display the number of visible (filtered) cards next to the list name in a small muted font, reusing the already-computed filtered cardIds.

<img width="288" height="446" alt="image" src="https://github.com/user-attachments/assets/4a7a758b-ca56-4699-8ef7-3b9b164fa04f" />


Closes: #1664 