### PR TITLE
Add board and list descriptions

### DIFF
--- a/client/src/components/boards/BoardActions/BoardActions.jsx
+++ b/client/src/components/boards/BoardActions/BoardActions.jsx
@@ -15,11 +15,13 @@ import { BoardContextIcons } from '../../../constants/Icons';
 import Filters from './Filters';
 import RightSide from './RightSide';
 import BoardMemberships from '../../board-memberships/BoardMemberships';
+import DescriptionPreview from '../../common/DescriptionPreview';
 
 import styles from './BoardActions.module.scss';
 
 const BoardActions = React.memo(() => {
-  const boardContext = useSelector((state) => selectors.selectCurrentBoard(state).context);
+  const board = useSelector(selectors.selectCurrentBoard);
+  const boardContext = board.context;
 
   const withContextTitle = boardContext !== BoardContexts.BOARD;
 
@@ -41,6 +43,11 @@ const BoardActions = React.memo(() => {
 
   return (
     <div className={styles.wrapper}>
+      {board.description && (
+        <DescriptionPreview maxLines={2} className={styles.description}>
+          {board.description}
+        </DescriptionPreview>
+      )}
       <div className={styles.actions}>
         {withContextTitle && (
           <div className={styles.action}>

--- a/client/src/components/boards/BoardActions/BoardActions.module.scss
+++ b/client/src/components/boards/BoardActions/BoardActions.module.scss
@@ -43,6 +43,12 @@
     margin-right: 8px;
   }
 
+  .description {
+    color: rgba(255, 255, 255, 0.88);
+    margin: 0 20px 10px;
+    max-width: 960px;
+  }
+
   .wrapper {
     overflow-x: auto;
     overflow-y: hidden;

--- a/client/src/components/boards/BoardSettingsModal/GeneralPane/EditInformation.jsx
+++ b/client/src/components/boards/BoardSettingsModal/GeneralPane/EditInformation.jsx
@@ -7,11 +7,13 @@ import { dequal } from 'dequal';
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { Button, Form, Input } from 'semantic-ui-react';
+import TextareaAutosize from 'react-textarea-autosize';
+import { Button, Form, Input, TextArea } from 'semantic-ui-react';
 
 import selectors from '../../../../selectors';
 import entryActions from '../../../../entry-actions';
 import { useForm, useNestedRef } from '../../../../hooks';
+import { isModifierKeyPressed } from '../../../../utils/event-helpers';
 
 import styles from './EditInformation.module.scss';
 
@@ -27,26 +29,29 @@ const EditInformation = React.memo(() => {
   const defaultData = useMemo(
     () => ({
       name: board.name,
+      description: board.description || null,
     }),
-    [board.name],
+    [board.name, board.description],
   );
 
   const [data, handleFieldChange] = useForm(() => ({
     name: '',
     ...defaultData,
+    description: defaultData.description || '',
   }));
 
   const cleanData = useMemo(
     () => ({
       ...data,
       name: data.name.trim(),
+      description: data.description.trim() || null,
     }),
     [data],
   );
 
   const [nameFieldRef, handleNameFieldRef] = useNestedRef('inputRef');
 
-  const handleSubmit = useCallback(() => {
+  const submit = useCallback(() => {
     if (!cleanData.name) {
       nameFieldRef.current.select();
       return;
@@ -54,6 +59,19 @@ const EditInformation = React.memo(() => {
 
     dispatch(entryActions.updateBoard(boardId, cleanData));
   }, [boardId, dispatch, cleanData, nameFieldRef]);
+
+  const handleSubmit = useCallback(() => {
+    submit();
+  }, [submit]);
+
+  const handleDescriptionKeyDown = useCallback(
+    (event) => {
+      if (isModifierKeyPressed(event) && event.key === 'Enter') {
+        submit();
+      }
+    },
+    [submit],
+  );
 
   return (
     <Form onSubmit={handleSubmit}>
@@ -65,6 +83,18 @@ const EditInformation = React.memo(() => {
         value={data.name}
         maxLength={128}
         className={styles.field}
+        onChange={handleFieldChange}
+      />
+      <div className={styles.text}>{t('common.description')}</div>
+      <TextArea
+        as={TextareaAutosize}
+        name="description"
+        value={data.description}
+        placeholder={t('common.enterDescription')}
+        maxLength={1024}
+        minRows={2}
+        className={styles.field}
+        onKeyDown={handleDescriptionKeyDown}
         onChange={handleFieldChange}
       />
       <Button positive disabled={dequal(cleanData, defaultData)} content={t('action.save')} />

--- a/client/src/components/common/DescriptionPreview/DescriptionPreview.jsx
+++ b/client/src/components/common/DescriptionPreview/DescriptionPreview.jsx
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import normalizeDescriptionPreviewText from '../../../utils/description-preview';
+
+import styles from './DescriptionPreview.module.scss';
+
+const DescriptionPreview = React.memo(({ children, maxLines, className }) => {
+  const text = useMemo(() => normalizeDescriptionPreviewText(children), [children]);
+
+  if (!text) {
+    return null;
+  }
+
+  return (
+    <div
+      title={text}
+      className={classNames(styles.wrapper, className)}
+      style={{ '--description-preview-lines': maxLines }}
+    >
+      {text}
+    </div>
+  );
+});
+
+DescriptionPreview.propTypes = {
+  children: PropTypes.string.isRequired,
+  maxLines: PropTypes.number,
+  className: PropTypes.string,
+};
+
+DescriptionPreview.defaultProps = {
+  maxLines: 2,
+  className: undefined,
+};
+
+export default DescriptionPreview;

--- a/client/src/components/common/DescriptionPreview/DescriptionPreview.module.scss
+++ b/client/src/components/common/DescriptionPreview/DescriptionPreview.module.scss
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+:global(#app) {
+  .wrapper {
+    display: -webkit-box;
+    font-size: 12px;
+    font-weight: normal;
+    line-height: 16px;
+    overflow: hidden;
+    overflow-wrap: break-word;
+    white-space: pre-wrap;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--description-preview-lines);
+    word-break: break-word;
+  }
+}

--- a/client/src/components/common/DescriptionPreview/index.js
+++ b/client/src/components/common/DescriptionPreview/index.js
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import DescriptionPreview from './DescriptionPreview';
+
+export default DescriptionPreview;

--- a/client/src/components/common/Static/Static.jsx
+++ b/client/src/components/common/Static/Static.jsx
@@ -95,6 +95,7 @@ const Static = React.memo(() => {
   } else {
     wrapperClassNames = [
       isFavoritesActive ? styles.wrapperBoardWithFavorites : styles.wrapperBoard,
+      board.description && styles.wrapperBoardWithDescription,
       [BoardViews.GRID, BoardViews.LIST].includes(board.view) && styles.wrapperVertical,
       styles.wrapperFlex,
     ];

--- a/client/src/components/common/Static/Static.module.scss
+++ b/client/src/components/common/Static/Static.module.scss
@@ -44,8 +44,16 @@
     margin-top: calc(174px + var(--promo-banner-height, 0px));
   }
 
+  .wrapperBoardWithDescription {
+    margin-top: calc(216px + var(--promo-banner-height, 0px));
+  }
+
   .wrapperBoardWithFavorites {
     margin-top: calc(264px + var(--promo-banner-height, 0px));
+  }
+
+  .wrapperBoardWithFavorites.wrapperBoardWithDescription {
+    margin-top: calc(306px + var(--promo-banner-height, 0px));
   }
 
   .wrapperFlex {

--- a/client/src/components/lists/List/ActionsStep.jsx
+++ b/client/src/components/lists/List/ActionsStep.jsx
@@ -15,6 +15,7 @@ import entryActions from '../../../entry-actions';
 import { useSteps } from '../../../hooks';
 import { ListTypes } from '../../../constants/Enums';
 import EditColorStep from './EditColorStep';
+import EditDescriptionStep from './EditDescriptionStep';
 import SortStep from './SortStep';
 import MoveStep from './MoveStep';
 import SelectListTypeStep from '../SelectListTypeStep';
@@ -26,6 +27,7 @@ import styles from './ActionsStep.module.scss';
 const StepTypes = {
   EDIT_TYPE: 'EDIT_TYPE',
   EDIT_COLOR: 'EDIT_COLOR',
+  EDIT_DESCRIPTION: 'EDIT_DESCRIPTION',
   SORT: 'SORT',
   MOVE: 'MOVE',
   ARCHIVE_CARDS: 'ARCHIVE_CARDS',
@@ -74,6 +76,10 @@ const ActionsStep = React.memo(({ listId, onNameEdit, onCardAdd, onClose }) => {
     openStep(StepTypes.EDIT_COLOR);
   }, [openStep]);
 
+  const handleEditDescriptionClick = useCallback(() => {
+    openStep(StepTypes.EDIT_DESCRIPTION);
+  }, [openStep]);
+
   const handleSortClick = useCallback(() => {
     openStep(StepTypes.SORT);
   }, [openStep]);
@@ -106,6 +112,8 @@ const ActionsStep = React.memo(({ listId, onNameEdit, onCardAdd, onClose }) => {
         );
       case StepTypes.EDIT_COLOR:
         return <EditColorStep listId={listId} onBack={handleBack} onClose={onClose} />;
+      case StepTypes.EDIT_DESCRIPTION:
+        return <EditDescriptionStep listId={listId} onBack={handleBack} onClose={onClose} />;
       case StepTypes.SORT:
         return <SortStep listId={listId} onBack={handleBack} onClose={onClose} />;
       case StepTypes.MOVE:
@@ -150,6 +158,12 @@ const ActionsStep = React.memo(({ listId, onNameEdit, onCardAdd, onClose }) => {
           <Menu.Item className={styles.menuItem} onClick={handleEditColorClick}>
             <Icon name="dot circle outline" className={styles.menuItemIcon} />
             {t('action.editColor', {
+              context: 'title',
+            })}
+          </Menu.Item>
+          <Menu.Item className={styles.menuItem} onClick={handleEditDescriptionClick}>
+            <Icon name="align left" className={styles.menuItemIcon} />
+            {t('action.editDescription', {
               context: 'title',
             })}
           </Menu.Item>

--- a/client/src/components/lists/List/EditDescriptionStep.jsx
+++ b/client/src/components/lists/List/EditDescriptionStep.jsx
@@ -1,0 +1,103 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import { dequal } from 'dequal';
+import React, { useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import TextareaAutosize from 'react-textarea-autosize';
+import { Button, Form, TextArea } from 'semantic-ui-react';
+import { Popup } from '../../../lib/custom-ui';
+
+import selectors from '../../../selectors';
+import entryActions from '../../../entry-actions';
+import { useForm } from '../../../hooks';
+import { isModifierKeyPressed } from '../../../utils/event-helpers';
+
+import styles from './EditDescriptionStep.module.scss';
+
+const EditDescriptionStep = React.memo(({ listId, onBack, onClose }) => {
+  const selectListById = useMemo(() => selectors.makeSelectListById(), []);
+
+  const defaultData = useSelector((state) => {
+    const list = selectListById(state, listId);
+
+    return {
+      description: list.description || null,
+    };
+  });
+
+  const dispatch = useDispatch();
+  const [t] = useTranslation();
+
+  const [data, handleFieldChange] = useForm(() => ({
+    ...defaultData,
+    description: defaultData.description || '',
+  }));
+
+  const cleanData = useMemo(
+    () => ({
+      description: data.description.trim() || null,
+    }),
+    [data.description],
+  );
+
+  const submit = useCallback(() => {
+    if (!dequal(cleanData, defaultData)) {
+      dispatch(entryActions.updateList(listId, cleanData));
+    }
+
+    onClose();
+  }, [listId, defaultData, cleanData, onClose, dispatch]);
+
+  const handleSubmit = useCallback(() => {
+    submit();
+  }, [submit]);
+
+  const handleDescriptionKeyDown = useCallback(
+    (event) => {
+      if (isModifierKeyPressed(event) && event.key === 'Enter') {
+        submit();
+      }
+    },
+    [submit],
+  );
+
+  return (
+    <>
+      <Popup.Header onBack={onBack}>
+        {t('action.editDescription', {
+          context: 'title',
+        })}
+      </Popup.Header>
+      <Popup.Content>
+        <Form onSubmit={handleSubmit}>
+          <TextArea
+            autoFocus
+            as={TextareaAutosize}
+            name="description"
+            value={data.description}
+            placeholder={t('common.enterDescription')}
+            maxLength={1024}
+            minRows={4}
+            className={styles.field}
+            onKeyDown={handleDescriptionKeyDown}
+            onChange={handleFieldChange}
+          />
+          <Button positive disabled={dequal(cleanData, defaultData)} content={t('action.save')} />
+        </Form>
+      </Popup.Content>
+    </>
+  );
+});
+
+EditDescriptionStep.propTypes = {
+  listId: PropTypes.string.isRequired,
+  onBack: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default EditDescriptionStep;

--- a/client/src/components/lists/List/EditDescriptionStep.module.scss
+++ b/client/src/components/lists/List/EditDescriptionStep.module.scss
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+:global(#app) {
+  .field {
+    margin-bottom: 8px;
+    resize: none;
+  }
+}

--- a/client/src/components/lists/List/List.jsx
+++ b/client/src/components/lists/List/List.jsx
@@ -26,6 +26,7 @@ import ActionsStep from './ActionsStep';
 import DraggableCard from '../../cards/DraggableCard';
 import AddCard from '../../cards/AddCard';
 import ArchiveCardsStep from '../../cards/ArchiveCardsStep';
+import DescriptionPreview from '../../common/DescriptionPreview';
 import PlusMathIcon from '../../../assets/images/plus-math-icon.svg?react';
 
 import styles from './List.module.scss';
@@ -227,6 +228,11 @@ const List = React.memo(({ id, index }) => {
                   )}
                   {list.name}
                 </div>
+              )}
+              {!isEditNameOpened && list.description && (
+                <DescriptionPreview maxLines={3} className={styles.headerDescription}>
+                  {list.description}
+                </DescriptionPreview>
               )}
               {list.type !== ListTypes.ACTIVE && (
                 <Icon

--- a/client/src/components/lists/List/List.module.scss
+++ b/client/src/components/lists/List/List.module.scss
@@ -155,6 +155,11 @@
     margin-right: 6px;
   }
 
+  .headerDescription {
+    color: #516b7a;
+    margin: -2px 8px 4px;
+  }
+
   .innerWrapper {
     margin-right: 8px;
     width: 272px;

--- a/client/src/models/Board.js
+++ b/client/src/models/Board.js
@@ -27,6 +27,7 @@ export default class extends BaseModel {
     id: attr(),
     position: attr(),
     name: attr(),
+    description: attr(),
     defaultView: attr(),
     defaultCardType: attr(),
     limitCardTypesToDefaultOne: attr(),

--- a/client/src/models/List.js
+++ b/client/src/models/List.js
@@ -52,6 +52,7 @@ export default class extends BaseModel {
     type: attr(),
     position: attr(),
     name: attr(),
+    description: attr(),
     color: attr(),
     lastCard: attr({
       getDefault: () => null,

--- a/client/src/utils/description-preview.js
+++ b/client/src/utils/description-preview.js
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+const normalizeDescriptionPreviewText = (value) => value.replace(/\r\n?/g, '\n');
+
+export default normalizeDescriptionPreviewText;

--- a/client/src/utils/description-preview.test.js
+++ b/client/src/utils/description-preview.test.js
@@ -1,0 +1,7 @@
+import normalizeDescriptionPreviewText from './description-preview';
+
+describe('normalizeDescriptionPreviewText', () => {
+  it('preserves multiline text while normalizing carriage returns', () => {
+    expect(normalizeDescriptionPreviewText('Ready\r\nReview\rDone')).toBe('Ready\nReview\nDone');
+  });
+});

--- a/server/api/controllers/boards/create.js
+++ b/server/api/controllers/boards/create.js
@@ -40,6 +40,12 @@
  *                 maxLength: 128
  *                 description: Name/title of the board
  *                 example: Development Board
+ *               description:
+ *                 type: string
+ *                 maxLength: 1024
+ *                 nullable: true
+ *                 description: Detailed description of the board
+ *                 example: Development workflow for the product team
  *               importType:
  *                 type: string
  *                 enum: [trello]
@@ -135,6 +141,12 @@ module.exports = {
       maxLength: 128,
       required: true,
     },
+    description: {
+      type: 'string',
+      isNotEmptyString: true,
+      maxLength: 1024,
+      allowNull: true,
+    },
     importType: {
       type: 'string',
       isIn: Object.values(Board.ImportTypes),
@@ -203,7 +215,7 @@ module.exports = {
       }
     }
 
-    const values = _.pick(inputs, ['position', 'name']);
+    const values = _.pick(inputs, ['position', 'name', 'description']);
 
     const { board, boardMembership } = await sails.helpers.boards.createOne.with({
       values: {

--- a/server/api/controllers/boards/update.js
+++ b/server/api/controllers/boards/update.js
@@ -37,6 +37,12 @@
  *                 maxLength: 128
  *                 description: Name/title of the board
  *                 example: Development Board
+ *               description:
+ *                 type: string
+ *                 maxLength: 1024
+ *                 nullable: true
+ *                 description: Detailed description of the board
+ *                 example: Development workflow for the product team
  *               defaultView:
  *                 type: string
  *                 enum: [kanban, grid, list]
@@ -110,6 +116,12 @@ module.exports = {
       isNotEmptyString: true,
       maxLength: 128,
     },
+    description: {
+      type: 'string',
+      isNotEmptyString: true,
+      maxLength: 1024,
+      allowNull: true,
+    },
     defaultView: {
       type: 'string',
       isIn: Object.values(Board.Views),
@@ -163,6 +175,7 @@ module.exports = {
       availableInputKeys.push(
         'position',
         'name',
+        'description',
         'defaultView',
         'defaultCardType',
         'limitCardTypesToDefaultOne',
@@ -182,6 +195,7 @@ module.exports = {
     const values = _.pick(inputs, [
       'position',
       'name',
+      'description',
       'defaultView',
       'defaultCardType',
       'limitCardTypesToDefaultOne',

--- a/server/api/controllers/lists/create.js
+++ b/server/api/controllers/lists/create.js
@@ -46,6 +46,12 @@
  *                 maxLength: 128
  *                 description: Name/title of the list
  *                 example: To Do
+ *               description:
+ *                 type: string
+ *                 maxLength: 1024
+ *                 nullable: true
+ *                 description: Detailed description of the list
+ *                 example: Cards that are ready to be picked up
  *     responses:
  *       200:
  *         description: List created successfully
@@ -100,6 +106,12 @@ module.exports = {
       maxLength: 128,
       required: true,
     },
+    description: {
+      type: 'string',
+      isNotEmptyString: true,
+      maxLength: 1024,
+      allowNull: true,
+    },
   },
 
   exits: {
@@ -131,7 +143,7 @@ module.exports = {
       throw Errors.NOT_ENOUGH_RIGHTS;
     }
 
-    const values = _.pick(inputs, ['type', 'position', 'name']);
+    const values = _.pick(inputs, ['type', 'position', 'name', 'description']);
 
     const list = await sails.helpers.lists.createOne.with({
       project,

--- a/server/api/controllers/lists/update.js
+++ b/server/api/controllers/lists/update.js
@@ -46,6 +46,12 @@
  *                 maxLength: 128
  *                 description: Name/title of the list
  *                 example: To Do
+ *               description:
+ *                 type: string
+ *                 maxLength: 1024
+ *                 nullable: true
+ *                 description: Detailed description of the list
+ *                 example: Cards that are ready to be picked up
  *               color:
  *                 type: string
  *                 enum: [berry-red, pumpkin-orange, lagoon-blue, pink-tulip, light-mud, orange-peel, bright-moss, antique-blue, dark-granite, turquoise-sea]
@@ -107,6 +113,12 @@ module.exports = {
       type: 'string',
       isNotEmptyString: true,
       maxLength: 128,
+    },
+    description: {
+      type: 'string',
+      isNotEmptyString: true,
+      maxLength: 1024,
+      allowNull: true,
     },
     color: {
       type: 'string',
@@ -176,7 +188,7 @@ module.exports = {
       }
     }
 
-    const values = _.pick(inputs, ['type', 'position', 'name', 'color']);
+    const values = _.pick(inputs, ['type', 'position', 'name', 'description', 'color']);
 
     list = await sails.helpers.lists.updateOne.with({
       project,

--- a/server/api/models/Board.js
+++ b/server/api/models/Board.js
@@ -21,6 +21,7 @@
  *         - projectId
  *         - position
  *         - name
+ *         - description
  *         - defaultView
  *         - defaultCardType
  *         - limitCardTypesToDefaultOne
@@ -46,6 +47,11 @@
  *           type: string
  *           description: Name/title of the board
  *           example: Development Board
+ *         description:
+ *           type: string
+ *           nullable: true
+ *           description: Detailed description of the board
+ *           example: Development workflow for the product team
  *         defaultView:
  *           type: string
  *           enum: [kanban, grid, list]
@@ -120,6 +126,11 @@ module.exports = {
     name: {
       type: 'string',
       required: true,
+    },
+    description: {
+      type: 'string',
+      isNotEmptyString: true,
+      allowNull: true,
     },
     defaultView: {
       type: 'string',

--- a/server/api/models/List.js
+++ b/server/api/models/List.js
@@ -22,6 +22,7 @@
  *         - type
  *         - position
  *         - name
+ *         - description
  *         - color
  *         - createdAt
  *         - updatedAt
@@ -49,6 +50,11 @@
  *           nullable: true
  *           description: Name/title of the list
  *           example: To Do
+ *         description:
+ *           type: string
+ *           nullable: true
+ *           description: Detailed description of the list
+ *           example: Cards that are ready to be picked up
  *         color:
  *           type: string
  *           enum: [berry-red, pumpkin-orange, lagoon-blue, pink-tulip, light-mud, orange-peel, bright-moss, antique-blue, dark-granite, turquoise-sea]
@@ -140,6 +146,11 @@ module.exports = {
       allowNull: true,
     },
     name: {
+      type: 'string',
+      isNotEmptyString: true,
+      allowNull: true,
+    },
+    description: {
       type: 'string',
       isNotEmptyString: true,
       allowNull: true,

--- a/server/db/migrations/20260605000000_add_board_and_list_descriptions.js
+++ b/server/db/migrations/20260605000000_add_board_and_list_descriptions.js
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+exports.up = async (knex) => {
+  await knex.schema.alterTable('board', (table) => {
+    table.text('description');
+  });
+
+  return knex.schema.alterTable('list', (table) => {
+    table.text('description');
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('list', (table) => {
+    table.dropColumn('description');
+  });
+
+  return knex.schema.alterTable('board', (table) => {
+    table.dropColumn('description');
+  });
+};

--- a/server/test/integration/models/BoardListDescriptions.test.js
+++ b/server/test/integration/models/BoardListDescriptions.test.js
@@ -1,0 +1,58 @@
+/* eslint-disable global-require */
+
+const { expect } = require('chai');
+
+describe('Board/List descriptions', () => {
+  it('should expose nullable description attributes on Board and List models', () => {
+    const boardModel = require('../../../api/models/Board');
+    const listModel = require('../../../api/models/List');
+
+    expect(boardModel.attributes.description).to.include({
+      type: 'string',
+      allowNull: true,
+    });
+
+    expect(listModel.attributes.description).to.include({
+      type: 'string',
+      allowNull: true,
+    });
+  });
+
+  it('should accept description in board create/update controller inputs', () => {
+    const createController = require('../../../api/controllers/boards/create');
+    const updateController = require('../../../api/controllers/boards/update');
+
+    expect(createController.inputs.description).to.include({
+      type: 'string',
+      isNotEmptyString: true,
+      maxLength: 1024,
+      allowNull: true,
+    });
+
+    expect(updateController.inputs.description).to.include({
+      type: 'string',
+      isNotEmptyString: true,
+      maxLength: 1024,
+      allowNull: true,
+    });
+  });
+
+  it('should accept description in list create/update controller inputs', () => {
+    const createController = require('../../../api/controllers/lists/create');
+    const updateController = require('../../../api/controllers/lists/update');
+
+    expect(createController.inputs.description).to.include({
+      type: 'string',
+      isNotEmptyString: true,
+      maxLength: 1024,
+      allowNull: true,
+    });
+
+    expect(updateController.inputs.description).to.include({
+      type: 'string',
+      isNotEmptyString: true,
+      maxLength: 1024,
+      allowNull: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds optional descriptions for boards and lists so teams can document the intended workflow and purpose of each board/list directly in the board view.

## Changes

- Added nullable `description` fields to boards and lists, including database migration, models, API validation, and Swagger docs.
- Added board description editing in Board Settings → General.
- Added list description editing from the list actions menu.
- Added compact plain-text description previews:
  - board descriptions display above the board action row
  - list descriptions display under the list title
- Adjusted board content spacing so the board action controls do not overlap cards when a board description is visible.
- Added backend contract tests and a small client utility test.
<img width="688" height="707" alt="image" src="https://github.com/user-attachments/assets/35e7606c-4caa-4ac4-afb1-1725d81d3f03" />

CLosed: #1485

## Testing

- `npm run server:lint`
- `PORT=1338 npm test --prefix server -- --exit`
- `npm run client:lint`
- `npm test --prefix client -- --runInBand`
- `npm run client:build`
- Verified the migration on a clean temporary Postgres database with migrate up/down.
- Manually checked board and list descriptions in the running dev UI.