### PR TITLE
Add OK button to board settings modal

### DIFF
--- a/client/src/components/boards/BoardSettingsModal/BoardSettingsModal.jsx
+++ b/client/src/components/boards/BoardSettingsModal/BoardSettingsModal.jsx
@@ -6,7 +6,7 @@
 import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { Tab } from 'semantic-ui-react';
+import { Button, Tab } from 'semantic-ui-react';
 
 import selectors from '../../../selectors';
 import entryActions from '../../../entry-actions';
@@ -14,6 +14,8 @@ import { useClosableModal } from '../../../hooks';
 import GeneralPane from './GeneralPane';
 import PreferencesPane from './PreferencesPane';
 import NotificationsPane from './NotificationsPane';
+
+import styles from './BoardSettingsModal.module.scss';
 
 const BoardSettingsModal = React.memo(() => {
   const openPreferences = useSelector(
@@ -61,6 +63,9 @@ const BoardSettingsModal = React.memo(() => {
           panes={panes}
           defaultActiveIndex={openPreferences ? 1 : undefined}
         />
+        <div className={styles.actions}>
+          <Button positive content="OK" onClick={handleClose} />
+        </div>
       </ClosableModal.Content>
     </ClosableModal>
   );

--- a/client/src/components/boards/BoardSettingsModal/BoardSettingsModal.module.scss
+++ b/client/src/components/boards/BoardSettingsModal/BoardSettingsModal.module.scss
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+:global(#app) {
+  .actions {
+    margin-top: 12px;
+    text-align: right;
+  }
+}


### PR DESCRIPTION
The board settings modal could only be closed via the X in the top-right corner. Added an OK button at the bottom of the modal content so there's an obvious way to dismiss it after you're done — same idea as the X, just easier to hit.

Placed it below the tab area so it stays visible on General, Preferences, and Notifications. It calls handleClose, which dispatches closeModal(), so nothing else about how the modal works changes.