### PR TITLE
feat:  A new Card Action Step menu - "Move to 'Done'" 

### DIFF
--- a/client/src/components/cards/CardActionsStep/CardActionsStep.jsx
+++ b/client/src/components/cards/CardActionsStep/CardActionsStep.jsx
@@ -55,6 +55,10 @@ const CardActionsStep = React.memo(({ cardId, defaultStep, onNameEdit, onClose }
   const userIds = useSelector((state) => selectUserIdsByCardId(state, cardId));
   const labelIds = useSelector((state) => selectLabelIdsByCardId(state, cardId));
 
+  const closedLists = useSelector((state) =>
+    selectors.selectAvailableListsForCurrentBoard(state),
+  ).filter((l) => l.type === ListTypes.CLOSED);
+
   const {
     canEditType,
     canEditName,
@@ -312,6 +316,14 @@ const CardActionsStep = React.memo(({ cardId, defaultStep, onNameEdit, onClose }
     openStep(StepTypes.MOVE);
   }, [openStep]);
 
+  const handleMoveToClosedListClick = useCallback(
+    (id) => {
+      dispatch(entryActions.moveCard(cardId, id, undefined, true));
+      onClose();
+    },
+    [dispatch, cardId, onClose],
+  );
+
   const handleArchiveClick = useCallback(() => {
     openStep(StepTypes.ARCHIVE);
   }, [openStep]);
@@ -485,6 +497,18 @@ const CardActionsStep = React.memo(({ cardId, defaultStep, onNameEdit, onClose }
               })}
             </Menu.Item>
           )}
+          {canMove &&
+            closedLists.length > 0 &&
+            closedLists.slice(0, 3).map((closedList) => (
+              <Menu.Item
+                className={styles.menuItem}
+                onClick={() => handleMoveToClosedListClick(closedList.id)}
+                key={closedList.id}
+              >
+                <Icon name="share square outline" className={styles.menuItemIcon} />
+                Move Card to &quot;{closedList.name}&quot;
+              </Menu.Item>
+            ))}
           {prevList && canRestore && (
             <Menu.Item className={styles.menuItem} onClick={handleRestoreClick}>
               <Icon name="undo alternate" className={styles.menuItemIcon} />


### PR DESCRIPTION
I've recently had to move a LOT of cards from Todo to DONE.

I realized a quick menu would be nice.

So here it is..
In CardActionStep all LISTS that are closed are scanned.
Then the first three CLOSED are added as menus "Move to 'xyz'",
(up to three so the menu doesn't get to long)

<img width="853" height="514" alt="Screenshot 2026-06-12 220357" src="https://github.com/user-attachments/assets/a9e25aa1-1ecb-4c0a-8154-35a2df1e9c22" />

To use it, you have to have lists with TYPE CLOSED.

This will come really handy - I think!

@meltyshev @daniel-hiller please review!