### PR TITLE
fix: Create admin user seed validation

### DIFF
--- a/server/db/create-admin-user.js
+++ b/server/db/create-admin-user.js
@@ -58,10 +58,19 @@ const input = async (fieldName, options = {}) => {
         validator.isEmail(process.env.DEFAULT_ADMIN_EMAIL) &&
         process.env.DEFAULT_ADMIN_EMAIL.length <= 256
       ) {
-        break;
+        const existingUser = await knex('user_account')
+          .where('email', process.env.DEFAULT_ADMIN_EMAIL.toLowerCase())
+          .first();
+
+        if (!existingUser) {
+          break;
+        }
+
+        console.log('Email is already in use.');
+      } else {
+        console.log('Email must be a valid e-mail address with no more than 256 characters.');
       }
 
-      console.log('Email must be a valid e-mail address with no more than 256 characters.');
       process.env.DEFAULT_ADMIN_EMAIL = await input('Email', {
         isRequired: true,
       });

--- a/server/db/create-admin-user.js
+++ b/server/db/create-admin-user.js
@@ -97,12 +97,20 @@ const input = async (fieldName, options = {}) => {
           USERNAME_REGEX.test(process.env.DEFAULT_ADMIN_USERNAME);
 
         if (isValid) {
-          break;
-        }
+          const existingUser = await knex('user_account')
+            .where('username', process.env.DEFAULT_ADMIN_USERNAME.toLowerCase())
+            .first();
 
-        console.log(
-          'Username must be 3-32 characters and contain only letters, digits, underscores, and dots (e.g., john_doe).',
-        );
+          if (!existingUser) {
+            break;
+          }
+
+          console.log('Username is already in use.');
+        } else {
+          console.log(
+            'Username must be 3-32 characters and contain only letters, digits, underscores, and dots (e.g., john_doe).',
+          );
+        }
 
         process.env.DEFAULT_ADMIN_USERNAME = await input('Username');
 

--- a/server/db/create-admin-user.js
+++ b/server/db/create-admin-user.js
@@ -62,6 +62,32 @@ const input = async (fieldName, options = {}) => {
 
     process.env.DEFAULT_ADMIN_USERNAME = await input('Username');
 
+    if (process.env.DEFAULT_ADMIN_USERNAME) {
+      const USERNAME_REGEX = /^[a-zA-Z0-9]+((_|\.)?[a-zA-Z0-9])*$/;
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const isValid =
+          process.env.DEFAULT_ADMIN_USERNAME.length >= 3 &&
+          process.env.DEFAULT_ADMIN_USERNAME.length <= 32 &&
+          USERNAME_REGEX.test(process.env.DEFAULT_ADMIN_USERNAME);
+
+        if (isValid) {
+          break;
+        }
+
+        console.log(
+          'Username must be 3-32 characters and contain only letters, digits, underscores, and dots (e.g., john_doe).',
+        );
+
+        process.env.DEFAULT_ADMIN_USERNAME = await input('Username');
+
+        if (!process.env.DEFAULT_ADMIN_USERNAME) {
+          break;
+        }
+      }
+    }
+
     await knex.seed.run({
       specific: 'default.js',
     });

--- a/server/db/create-admin-user.js
+++ b/server/db/create-admin-user.js
@@ -60,6 +60,14 @@ const input = async (fieldName, options = {}) => {
       isRequired: true,
     });
 
+    // eslint-disable-next-line no-constant-condition
+    while (process.env.DEFAULT_ADMIN_NAME.length > 128) {
+      console.log('Name must be no more than 128 characters.');
+      process.env.DEFAULT_ADMIN_NAME = await input('Name', {
+        isRequired: true,
+      });
+    }
+
     process.env.DEFAULT_ADMIN_USERNAME = await input('Username');
 
     if (process.env.DEFAULT_ADMIN_USERNAME) {

--- a/server/db/create-admin-user.js
+++ b/server/db/create-admin-user.js
@@ -48,32 +48,28 @@ const input = async (fieldName, options = {}) => {
   try {
     await knex.migrate.latest();
 
-    process.env.DEFAULT_ADMIN_EMAIL = await input('Email', {
-      isRequired: true,
-    });
+    let isEmailValid = false;
+    while (!isEmailValid) {
+      process.env.DEFAULT_ADMIN_EMAIL = await input('Email', {
+        isRequired: true,
+      });
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
       if (
-        validator.isEmail(process.env.DEFAULT_ADMIN_EMAIL) &&
-        process.env.DEFAULT_ADMIN_EMAIL.length <= 256
+        !validator.isEmail(process.env.DEFAULT_ADMIN_EMAIL) ||
+        process.env.DEFAULT_ADMIN_EMAIL.length > 256
       ) {
+        console.log('Email must be a valid e-mail address with no more than 256 characters.');
+      } else {
         const existingUser = await knex('user_account')
           .where('email', process.env.DEFAULT_ADMIN_EMAIL.toLowerCase())
           .first();
 
-        if (!existingUser) {
-          break;
+        if (existingUser) {
+          console.log('Email is already in use.');
+        } else {
+          isEmailValid = true;
         }
-
-        console.log('Email is already in use.');
-      } else {
-        console.log('Email must be a valid e-mail address with no more than 256 characters.');
       }
-
-      process.env.DEFAULT_ADMIN_EMAIL = await input('Email', {
-        isRequired: true,
-      });
     }
 
     process.env.DEFAULT_ADMIN_PASSWORD = await input('Password', {
@@ -85,7 +81,6 @@ const input = async (fieldName, options = {}) => {
       isRequired: true,
     });
 
-    // eslint-disable-next-line no-constant-condition
     while (process.env.DEFAULT_ADMIN_NAME.length > 128) {
       console.log('Name must be no more than 128 characters.');
       process.env.DEFAULT_ADMIN_NAME = await input('Name', {
@@ -93,38 +88,34 @@ const input = async (fieldName, options = {}) => {
       });
     }
 
-    process.env.DEFAULT_ADMIN_USERNAME = await input('Username');
+    const USERNAME_REGEX = /^[a-zA-Z0-9]+((_|\.)?[a-zA-Z0-9])*$/;
 
-    if (process.env.DEFAULT_ADMIN_USERNAME) {
-      const USERNAME_REGEX = /^[a-zA-Z0-9]+((_|\.)?[a-zA-Z0-9])*$/;
+    let isUsernameValid = false;
+    while (!isUsernameValid) {
+      process.env.DEFAULT_ADMIN_USERNAME = await input('Username');
 
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        const isValid =
-          process.env.DEFAULT_ADMIN_USERNAME.length >= 3 &&
-          process.env.DEFAULT_ADMIN_USERNAME.length <= 32 &&
-          USERNAME_REGEX.test(process.env.DEFAULT_ADMIN_USERNAME);
+      if (!process.env.DEFAULT_ADMIN_USERNAME) {
+        break;
+      }
 
-        if (isValid) {
-          const existingUser = await knex('user_account')
-            .where('username', process.env.DEFAULT_ADMIN_USERNAME.toLowerCase())
-            .first();
+      const isValid =
+        process.env.DEFAULT_ADMIN_USERNAME.length >= 3 &&
+        process.env.DEFAULT_ADMIN_USERNAME.length <= 32 &&
+        USERNAME_REGEX.test(process.env.DEFAULT_ADMIN_USERNAME);
 
-          if (!existingUser) {
-            break;
-          }
+      if (!isValid) {
+        console.log(
+          'Username must be 3-32 characters and contain only letters, digits, underscores, and dots (e.g., john_doe).',
+        );
+      } else {
+        const existingUser = await knex('user_account')
+          .where('username', process.env.DEFAULT_ADMIN_USERNAME.toLowerCase())
+          .first();
 
+        if (existingUser) {
           console.log('Username is already in use.');
         } else {
-          console.log(
-            'Username must be 3-32 characters and contain only letters, digits, underscores, and dots (e.g., john_doe).',
-          );
-        }
-
-        process.env.DEFAULT_ADMIN_USERNAME = await input('Username');
-
-        if (!process.env.DEFAULT_ADMIN_USERNAME) {
-          break;
+          isUsernameValid = true;
         }
       }
     }

--- a/server/db/create-admin-user.js
+++ b/server/db/create-admin-user.js
@@ -7,6 +7,7 @@
 /* eslint-disable no-console */
 
 const { read } = require('read');
+const validator = require('validator');
 const initKnex = require('knex');
 
 const knexfile = require('./knexfile');
@@ -50,6 +51,21 @@ const input = async (fieldName, options = {}) => {
     process.env.DEFAULT_ADMIN_EMAIL = await input('Email', {
       isRequired: true,
     });
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (
+        validator.isEmail(process.env.DEFAULT_ADMIN_EMAIL) &&
+        process.env.DEFAULT_ADMIN_EMAIL.length <= 256
+      ) {
+        break;
+      }
+
+      console.log('Email must be a valid e-mail address with no more than 256 characters.');
+      process.env.DEFAULT_ADMIN_EMAIL = await input('Email', {
+        isRequired: true,
+      });
+    }
 
     process.env.DEFAULT_ADMIN_PASSWORD = await input('Password', {
       isRequired: true,

--- a/server/db/create-admin-user.js
+++ b/server/db/create-admin-user.js
@@ -8,6 +8,7 @@
 
 const { read } = require('read');
 const validator = require('validator');
+const zxcvbn = require('zxcvbn');
 const initKnex = require('knex');
 
 const knexfile = require('./knexfile');
@@ -72,10 +73,19 @@ const input = async (fieldName, options = {}) => {
       }
     }
 
-    process.env.DEFAULT_ADMIN_PASSWORD = await input('Password', {
-      isRequired: true,
-      isPassword: true,
-    });
+    let isPasswordValid = false;
+    while (!isPasswordValid) {
+      process.env.DEFAULT_ADMIN_PASSWORD = await input('Password', {
+        isRequired: true,
+        isPassword: true,
+      });
+
+      if (zxcvbn(process.env.DEFAULT_ADMIN_PASSWORD).score >= 2) {
+        isPasswordValid = true;
+      } else {
+        console.log('Password is too weak. Choose a stronger password.');
+      }
+    }
 
     process.env.DEFAULT_ADMIN_NAME = await input('Name', {
       isRequired: true,

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -78,6 +78,16 @@ exports.seed = async (knex) => {
 
     const userData = buildUserData();
 
+    if (userData.username) {
+      const existingUsernameUser = await knex('user_account')
+        .where('username', userData.username)
+        .first();
+
+      if (existingUsernameUser) {
+        throw new Error(`User with DEFAULT_ADMIN_USERNAME "${userData.username}" already exists.`);
+      }
+    }
+
     let userId;
     try {
       [{ id: userId }] = await knex('user_account').insert(

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -6,6 +6,7 @@
 /* eslint-disable no-console */
 
 const bcrypt = require('bcrypt');
+const validator = require('validator');
 
 const USERNAME_REGEX = /^[a-zA-Z0-9]+((_|\.)?[a-zA-Z0-9])*$/;
 
@@ -24,7 +25,7 @@ const buildUserData = () => {
       console.warn('Warning: DEFAULT_ADMIN_NAME exceeds 128 characters; truncating.');
       data.name = process.env.DEFAULT_ADMIN_NAME.slice(0, 128);
     } else {
-    data.name = process.env.DEFAULT_ADMIN_NAME;
+      data.name = process.env.DEFAULT_ADMIN_NAME;
     }
   }
   if (process.env.DEFAULT_ADMIN_USERNAME) {
@@ -63,6 +64,18 @@ exports.seed = async (knex) => {
     process.env.DEFAULT_ADMIN_EMAIL && process.env.DEFAULT_ADMIN_EMAIL.toLowerCase();
 
   if (defaultAdminEmail) {
+    if (!validator.isEmail(defaultAdminEmail)) {
+      throw new Error(
+        `DEFAULT_ADMIN_EMAIL "${process.env.DEFAULT_ADMIN_EMAIL}" is not a valid e-mail address.`,
+      );
+    }
+
+    if (defaultAdminEmail.length > 256) {
+      throw new Error(
+        `DEFAULT_ADMIN_EMAIL "${process.env.DEFAULT_ADMIN_EMAIL}" exceeds 256 characters.`,
+      );
+    }
+
     const userData = buildUserData();
 
     let userId;

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -20,7 +20,12 @@ const buildUserData = () => {
     data.password = bcrypt.hashSync(process.env.DEFAULT_ADMIN_PASSWORD, 10);
   }
   if (process.env.DEFAULT_ADMIN_NAME) {
+    if (process.env.DEFAULT_ADMIN_NAME.length > 128) {
+      console.warn('Warning: DEFAULT_ADMIN_NAME exceeds 128 characters; truncating.');
+      data.name = process.env.DEFAULT_ADMIN_NAME.slice(0, 128);
+    } else {
     data.name = process.env.DEFAULT_ADMIN_NAME;
+    }
   }
   if (process.env.DEFAULT_ADMIN_USERNAME) {
     const username = process.env.DEFAULT_ADMIN_USERNAME.toLowerCase();

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -3,7 +3,11 @@
  * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
  */
 
+/* eslint-disable no-console */
+
 const bcrypt = require('bcrypt');
+
+const USERNAME_REGEX = /^[a-zA-Z0-9]+((_|\.)?[a-zA-Z0-9])*$/;
 
 const buildUserData = () => {
   const data = {
@@ -19,7 +23,15 @@ const buildUserData = () => {
     data.name = process.env.DEFAULT_ADMIN_NAME;
   }
   if (process.env.DEFAULT_ADMIN_USERNAME) {
-    data.username = process.env.DEFAULT_ADMIN_USERNAME.toLowerCase();
+    const username = process.env.DEFAULT_ADMIN_USERNAME.toLowerCase();
+
+    if (username.length < 3 || username.length > 32 || !USERNAME_REGEX.test(username)) {
+      console.warn(
+        `Warning: DEFAULT_ADMIN_USERNAME "${process.env.DEFAULT_ADMIN_USERNAME}" is invalid; skipping.`,
+      );
+    } else {
+      data.username = username;
+    }
   }
 
   return data;

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -76,6 +76,12 @@ exports.seed = async (knex) => {
       );
     }
 
+    const existingEmailUser = await knex('user_account').where('email', defaultAdminEmail).first();
+
+    if (existingEmailUser) {
+      throw new Error(`User with DEFAULT_ADMIN_EMAIL "${defaultAdminEmail}" already exists.`);
+    }
+
     const userData = buildUserData();
 
     if (userData.username) {


### PR DESCRIPTION
The create admin user process using `docker compose run --rm planka npm run db:create-admin-user` lacked validation, allowing invalid data to be inserted into the database.

This PR validates the `email`, `name`, `username`, and `password` inputs based on the same length, regex, format, complexity, and uniqueness constraints found in the controller.

The user is re-prompted on failed input per field.