### PR TITLE
fix: Show error messages on invalid login and user settings form inputs

### DIFF
--- a/client/src/components/common/AdministrationModal/UsersPane/AddStep.jsx
+++ b/client/src/components/common/AdministrationModal/UsersPane/AddStep.jsx
@@ -15,6 +15,7 @@ import { Input, Popup } from '../../../../lib/custom-ui';
 
 import selectors from '../../../../selectors';
 import entryActions from '../../../../entry-actions';
+import actions from '../../../../actions';
 import { useForm, useNestedRef, useSteps } from '../../../../hooks';
 import { isPassword, isUsername } from '../../../../utils/validator';
 import { UserRoles } from '../../../../constants/Enums';
@@ -42,6 +43,11 @@ const createMessage = (error) => {
       return {
         type: 'error',
         content: 'common.usernameAlreadyInUse',
+      };
+    case 'Invalid email or username':
+      return {
+        type: 'error',
+        content: 'common.invalidEmailOrUsername',
       };
     default:
       return {
@@ -85,6 +91,7 @@ const AddStep = React.memo(({ onClose }) => {
 
     if (!isEmail(cleanData.email)) {
       emailFieldRef.current.select();
+      dispatch(actions.createUser.failure(new Error('Invalid email or username')));
       return;
     }
 
@@ -100,6 +107,7 @@ const AddStep = React.memo(({ onClose }) => {
 
     if (cleanData.username && !isUsername(cleanData.username)) {
       usernameFieldRef.current.select();
+      dispatch(actions.createUser.failure(new Error('Invalid email or username')));
       return;
     }
 

--- a/client/src/components/common/Login/Content.jsx
+++ b/client/src/components/common/Login/Content.jsx
@@ -15,6 +15,7 @@ import { Input } from '../../../lib/custom-ui';
 
 import selectors from '../../../selectors';
 import entryActions from '../../../entry-actions';
+import actions from '../../../actions';
 import { useForm, useNestedRef } from '../../../hooks';
 import { isUsername } from '../../../utils/validator';
 import AccessTokenSteps from '../../../constants/AccessTokenSteps';
@@ -144,11 +145,13 @@ const Content = React.memo(() => {
 
     if (!isEmail(cleanData.emailOrUsername) && !isUsername(cleanData.emailOrUsername)) {
       emailOrUsernameFieldRef.current.select();
+      dispatch(actions.authenticate.failure(new Error('Invalid email or username')));
       return;
     }
 
     if (!cleanData.password) {
       passwordFieldRef.current.focus();
+      dispatch(actions.authenticate.failure(new Error('Invalid password')));
       return;
     }
 

--- a/client/src/components/users/EditUserEmailStep/EditUserEmailStep.jsx
+++ b/client/src/components/users/EditUserEmailStep/EditUserEmailStep.jsx
@@ -14,6 +14,7 @@ import { Input, Popup } from '../../../lib/custom-ui';
 
 import selectors from '../../../selectors';
 import entryActions from '../../../entry-actions';
+import actions from '../../../actions';
 import { useForm, useNestedRef } from '../../../hooks';
 
 import styles from './EditUserEmailStep.module.scss';
@@ -33,6 +34,11 @@ const createMessage = (error) => {
       return {
         type: 'error',
         content: 'common.invalidCurrentPassword',
+      };
+    case 'Invalid email or username':
+      return {
+        type: 'error',
+        content: 'common.invalidEmailOrUsername',
       };
     default:
       return {
@@ -79,6 +85,7 @@ const EditUserEmailStep = React.memo(({ id, onBack, onClose }) => {
 
     if (!isEmail(cleanData.email)) {
       emailFieldRef.current.select();
+      dispatch(actions.updateUserEmail.failure(id, new Error('Invalid email or username')));
       return;
     }
 
@@ -90,6 +97,7 @@ const EditUserEmailStep = React.memo(({ id, onBack, onClose }) => {
     if (withPasswordConfirmation) {
       if (!cleanData.currentPassword) {
         currentPasswordFieldRef.current.focus();
+        dispatch(actions.updateUserEmail.failure(id, new Error('Invalid current password')));
         return;
       }
     } else {

--- a/client/src/components/users/EditUserPasswordStep/EditUserPasswordStep.jsx
+++ b/client/src/components/users/EditUserPasswordStep/EditUserPasswordStep.jsx
@@ -14,6 +14,7 @@ import { Input, Popup } from '../../../lib/custom-ui';
 
 import selectors from '../../../selectors';
 import entryActions from '../../../entry-actions';
+import actions from '../../../actions';
 import { useForm, useNestedRef } from '../../../hooks';
 import { isPassword } from '../../../utils/validator';
 
@@ -29,6 +30,11 @@ const createMessage = (error) => {
       return {
         type: 'error',
         content: 'common.invalidCurrentPassword',
+      };
+    case 'Invalid password':
+      return {
+        type: 'error',
+        content: 'common.invalidPassword',
       };
     default:
       return {
@@ -69,11 +75,13 @@ const EditUserPasswordStep = React.memo(({ id, onBack, onClose }) => {
   const handleSubmit = useCallback(() => {
     if (!data.password || !isPassword(data.password)) {
       passwordFieldRef.current.select();
+      dispatch(actions.updateUserPassword.failure(id, new Error('Invalid password')));
       return;
     }
 
     if (withPasswordConfirmation && !data.currentPassword) {
       currentPasswordFieldRef.current.focus();
+      dispatch(actions.updateUserPassword.failure(id, new Error('Invalid current password')));
       return;
     }
 

--- a/client/src/components/users/EditUserUsernameStep/EditUserUsernameStep.jsx
+++ b/client/src/components/users/EditUserUsernameStep/EditUserUsernameStep.jsx
@@ -13,6 +13,7 @@ import { Input, Popup } from '../../../lib/custom-ui';
 
 import selectors from '../../../selectors';
 import entryActions from '../../../entry-actions';
+import actions from '../../../actions';
 import { useForm, useNestedRef } from '../../../hooks';
 import { isUsername } from '../../../utils/validator';
 
@@ -33,6 +34,11 @@ const createMessage = (error) => {
       return {
         type: 'error',
         content: 'common.invalidCurrentPassword',
+      };
+    case 'Invalid email or username':
+      return {
+        type: 'error',
+        content: 'common.invalidEmailOrUsername',
       };
     default:
       return {
@@ -79,6 +85,7 @@ const EditUserUsernameStep = React.memo(({ id, onBack, onClose }) => {
 
     if (!cleanData.username || !isUsername(cleanData.username)) {
       usernameFieldRef.current.select();
+      dispatch(actions.updateUserUsername.failure(id, new Error('Invalid email or username')));
       return;
     }
 
@@ -90,6 +97,7 @@ const EditUserUsernameStep = React.memo(({ id, onBack, onClose }) => {
     if (withPasswordConfirmation) {
       if (!cleanData.currentPassword) {
         currentPasswordFieldRef.current.focus();
+        dispatch(actions.updateUserUsername.failure(id, new Error('Invalid current password')));
         return;
       }
     } else {


### PR DESCRIPTION
Invalid data input into the login form or the admin user update forms silently failed.

### Previous behaviour

Submitting the form with invalid username/email/password would select or focus the field without providing any information.

### New behaviour

Submitting the form shows a failure message such as "Invalid e-mail or username" or "Invalid password".