### PR TITLE
feat: Add priority to cards#936

### DIFF
--- a/client/src/components/cards/Card/ProjectContent.jsx
+++ b/client/src/components/cards/Card/ProjectContent.jsx
@@ -15,6 +15,7 @@ import { startStopwatch, stopStopwatch } from '../../../utils/stopwatch';
 import { isListArchiveOrTrash } from '../../../utils/record-helpers';
 import { BoardMembershipRoles, BoardViews } from '../../../constants/Enums';
 import TaskList from './TaskList';
+import PriorityChip from '../PriorityChip';
 import DueDateChip from '../DueDateChip';
 import StopwatchChip from '../StopwatchChip';
 import TimeAgo from '../../common/TimeAgo';
@@ -114,6 +115,7 @@ const ProjectContent = React.memo(({ cardId }) => {
 
   const hasInformation =
     card.description ||
+    card.priority > 0 ||
     card.dueDate ||
     card.stopwatch ||
     card.commentsTotal > 0 ||
@@ -186,6 +188,11 @@ const ProjectContent = React.memo(({ cardId }) => {
               className={classNames(styles.attachment, styles.attachmentLeft, styles.notification)}
             >
               {notificationsTotal}
+            </span>
+          )}
+          {card.priority > 0 && (
+            <span className={classNames(styles.attachment, styles.attachmentLeft)}>
+              <PriorityChip value={card.priority} size="tiny" />
             </span>
           )}
           {card.dueDate && (

--- a/client/src/components/cards/CardModal/ProjectContent.jsx
+++ b/client/src/components/cards/CardModal/ProjectContent.jsx
@@ -26,8 +26,10 @@ import CreationDetailsStep from './CreationDetailsStep';
 import MoreActionsStep from './MoreActionsStep';
 import DueDateChip from '../DueDateChip';
 import StopwatchChip from '../StopwatchChip';
+import PriorityChip from '../PriorityChip';
 import EditDueDateStep from '../EditDueDateStep';
 import EditStopwatchStep from '../EditStopwatchStep';
+import EditPriorityStep from '../EditPriorityStep';
 import ExpandableMarkdown from '../../common/ExpandableMarkdown';
 import EditMarkdown from '../../common/EditMarkdown';
 import ConfirmationStep from '../../common/ConfirmationStep';
@@ -71,6 +73,7 @@ const ProjectContent = React.memo(() => {
     canEditDescription,
     canEditDueDate,
     canEditStopwatch,
+    canEditPriority,
     canSubscribe,
     canJoin,
     canDuplicate,
@@ -102,6 +105,7 @@ const ProjectContent = React.memo(() => {
         canEditDescription: false,
         canEditDueDate: false,
         canEditStopwatch: false,
+        canEditPriority: false,
         canSubscribe: isMember,
         canJoin: false,
         canDuplicate: false,
@@ -124,6 +128,7 @@ const ProjectContent = React.memo(() => {
       canEditDescription: isEditor,
       canEditDueDate: isEditor,
       canEditStopwatch: isEditor,
+      canEditPriority: isEditor,
       canSubscribe: isMember,
       canJoin: isEditor,
       canDuplicate: isEditor,
@@ -289,6 +294,7 @@ const ProjectContent = React.memo(() => {
   const ListsPopup = usePopupInClosableContext(ListsStep);
   const EditDueDatePopup = usePopupInClosableContext(EditDueDateStep);
   const EditStopwatchPopup = usePopupInClosableContext(EditStopwatchStep);
+  const EditPriorityPopup = usePopupInClosableContext(EditPriorityStep);
   const AddTaskListPopup = usePopupInClosableContext(AddTaskListStep);
   const AddAttachmentPopup = usePopupInClosableContext(AddAttachmentStep);
   const AddCustomFieldGroupPopup = usePopupInClosableContext(AddCustomFieldGroupStep);
@@ -313,7 +319,8 @@ const ProjectContent = React.memo(() => {
       </Grid.Row>
       <Grid.Row className={styles.modalPadding}>
         <Grid.Column width={12} className={styles.contentPadding}>
-          {(card.dueDate ||
+          {(card.priority > 0 ||
+            card.dueDate ||
             card.stopwatch ||
             board.alwaysDisplayCardCreator ||
             userIds.length > 0 ||
@@ -409,6 +416,24 @@ const ProjectContent = React.memo(() => {
                       </button>
                     </LabelsPopup>
                   )}
+                </div>
+              )}
+              {card.priority > 0 && (
+                <div className={styles.attachments}>
+                  <div className={styles.text}>
+                    {t('common.priority', {
+                      context: 'title',
+                    })}
+                  </div>
+                  <span className={styles.attachment}>
+                    {canEditPriority ? (
+                      <EditPriorityPopup cardId={card.id}>
+                        <PriorityChip value={card.priority} />
+                      </EditPriorityPopup>
+                    ) : (
+                      <PriorityChip value={card.priority} />
+                    )}
+                  </span>
                 </div>
               )}
               {card.dueDate && (
@@ -571,7 +596,8 @@ const ProjectContent = React.memo(() => {
                 )}
               </div>
             </div>
-            {(canEditDueDate ||
+            {(canEditPriority ||
+              canEditDueDate ||
               canEditStopwatch ||
               canUseMembers ||
               canUseLabels ||
@@ -580,6 +606,16 @@ const ProjectContent = React.memo(() => {
               canAddCustomFieldGroup) && (
               <div className={styles.actions}>
                 <span className={styles.actionsTitle}>{t('action.addToCard')}</span>
+                {canEditPriority && (
+                  <EditPriorityPopup cardId={card.id}>
+                    <Button fluid className={classNames(styles.actionButton, styles.hidable)}>
+                      <Icon name="exclamation circle" className={styles.actionIcon} />
+                      {t('common.priority', {
+                        context: 'title',
+                      })}
+                    </Button>
+                  </EditPriorityPopup>
+                )}
                 {canUseMembers && (
                   <BoardMembershipsPopup
                     currentUserIds={userIds}

--- a/client/src/components/cards/EditPriorityStep/EditPriorityStep.jsx
+++ b/client/src/components/cards/EditPriorityStep/EditPriorityStep.jsx
@@ -1,0 +1,110 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { Button, Form } from 'semantic-ui-react';
+import { Popup } from '../../../lib/custom-ui';
+
+import selectors from '../../../selectors';
+import entryActions from '../../../entry-actions';
+import {
+  CARD_PRIORITY_MAX,
+  CARD_PRIORITY_MIN,
+  getCardPriorityColor,
+} from '../../../constants/CardPriorities';
+import PriorityChip from '../PriorityChip';
+
+import styles from './EditPriorityStep.module.scss';
+
+const EditPriorityStep = React.memo(({ cardId, onBack, onClose }) => {
+  const selectCardById = useMemo(() => selectors.makeSelectCardById(), []);
+  const defaultValue = useSelector((state) => selectCardById(state, cardId).priority);
+
+  const dispatch = useDispatch();
+  const [t] = useTranslation();
+
+  const [value, setValue] = useState(defaultValue || CARD_PRIORITY_MIN);
+
+  const handleRangeChange = useCallback((event) => {
+    setValue(Number(event.target.value));
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    if (value !== defaultValue) {
+      dispatch(
+        entryActions.updateCard(cardId, {
+          priority: value,
+        }),
+      );
+    }
+
+    onClose();
+  }, [cardId, onClose, defaultValue, dispatch, value]);
+
+  const handleClearClick = useCallback(() => {
+    if (defaultValue) {
+      dispatch(
+        entryActions.updateCard(cardId, {
+          priority: 0,
+        }),
+      );
+    }
+
+    onClose();
+  }, [cardId, onClose, defaultValue, dispatch]);
+
+  return (
+    <>
+      <Popup.Header onBack={onBack}>
+        {t('common.priority', {
+          context: 'title',
+        })}
+      </Popup.Header>
+      <Popup.Content>
+        <Form onSubmit={handleSubmit}>
+          <div className={styles.previewWrapper}>
+            <PriorityChip value={value} />
+          </div>
+          <input
+            type="range"
+            min={CARD_PRIORITY_MIN}
+            max={CARD_PRIORITY_MAX}
+            step={1}
+            value={value}
+            style={{
+              '--priority-color': getCardPriorityColor(value),
+            }}
+            className={styles.range}
+            onChange={handleRangeChange}
+          />
+          <Button positive content={t('action.save')} />
+        </Form>
+        {!!defaultValue && (
+          <Button
+            negative
+            content={t('action.remove')}
+            className={styles.deleteButton}
+            onClick={handleClearClick}
+          />
+        )}
+      </Popup.Content>
+    </>
+  );
+});
+
+EditPriorityStep.propTypes = {
+  cardId: PropTypes.string.isRequired,
+  onBack: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
+};
+
+EditPriorityStep.defaultProps = {
+  onBack: undefined,
+};
+
+export default EditPriorityStep;

--- a/client/src/components/cards/EditPriorityStep/EditPriorityStep.module.scss
+++ b/client/src/components/cards/EditPriorityStep/EditPriorityStep.module.scss
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+:global(#app) {
+  .deleteButton {
+    bottom: 12px;
+    box-shadow: 0 1px 0 #cbcccc;
+    position: absolute;
+    right: 9px;
+  }
+
+  .previewWrapper {
+    margin-bottom: 12px;
+    text-align: center;
+  }
+
+  .range {
+    -webkit-appearance: none;
+    background: transparent;
+    display: block;
+    margin: 0 0 16px;
+    width: 100%;
+
+    &::-webkit-slider-runnable-track {
+      background: var(--priority-color);
+      border-radius: 3px;
+      height: 6px;
+    }
+
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      background: #fff;
+      border: 2px solid var(--priority-color);
+      border-radius: 50%;
+      height: 18px;
+      margin-top: -6px;
+      width: 18px;
+    }
+
+    &::-moz-range-track {
+      background: var(--priority-color);
+      border-radius: 3px;
+      height: 6px;
+    }
+
+    &::-moz-range-thumb {
+      background: #fff;
+      border: 2px solid var(--priority-color);
+      border-radius: 50%;
+      height: 18px;
+      width: 18px;
+    }
+  }
+}

--- a/client/src/components/cards/EditPriorityStep/index.js
+++ b/client/src/components/cards/EditPriorityStep/index.js
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import EditPriorityStep from './EditPriorityStep';
+
+export default EditPriorityStep;

--- a/client/src/components/cards/PriorityChip/PriorityChip.jsx
+++ b/client/src/components/cards/PriorityChip/PriorityChip.jsx
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import upperFirst from 'lodash/upperFirst';
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import { getCardPriorityColor } from '../../../constants/CardPriorities';
+
+import styles from './PriorityChip.module.scss';
+
+const Sizes = {
+  TINY: 'tiny',
+  SMALL: 'small',
+  MEDIUM: 'medium',
+};
+
+const PriorityChip = React.memo(({ value, size, isDisabled, onClick }) => {
+  const contentNode = (
+    <span
+      style={{
+        '--priority-color': getCardPriorityColor(value),
+      }}
+      className={classNames(styles.wrapper, styles[`wrapper${upperFirst(size)}`])}
+    >
+      {value}
+    </span>
+  );
+
+  return onClick ? (
+    <button type="button" disabled={isDisabled} className={styles.button} onClick={onClick}>
+      {contentNode}
+    </button>
+  ) : (
+    contentNode
+  );
+});
+
+PriorityChip.propTypes = {
+  value: PropTypes.number.isRequired,
+  size: PropTypes.oneOf(Object.values(Sizes)),
+  isDisabled: PropTypes.bool,
+  onClick: PropTypes.func,
+};
+
+PriorityChip.defaultProps = {
+  size: Sizes.MEDIUM,
+  isDisabled: false,
+  onClick: undefined,
+};
+
+export default PriorityChip;

--- a/client/src/components/cards/PriorityChip/PriorityChip.module.scss
+++ b/client/src/components/cards/PriorityChip/PriorityChip.module.scss
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+:global(#app) {
+  .button {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    display: inline-block;
+    outline: none;
+    padding: 0;
+  }
+
+  .wrapper {
+    background: var(--priority-color);
+    border-radius: 3px;
+    color: #fff;
+    display: inline-block;
+    font-weight: bold;
+    white-space: nowrap;
+  }
+
+  /* Sizes */
+
+  .wrapperTiny {
+    font-size: 12px;
+    line-height: 20px;
+    padding: 0px 6px;
+  }
+
+  .wrapperSmall {
+    font-size: 12px;
+    line-height: 20px;
+    padding: 2px 8px;
+  }
+
+  .wrapperMedium {
+    line-height: 20px;
+    padding: 6px 12px;
+  }
+}

--- a/client/src/components/cards/PriorityChip/index.js
+++ b/client/src/components/cards/PriorityChip/index.js
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+import PriorityChip from './PriorityChip';
+
+export default PriorityChip;

--- a/client/src/constants/CardPriorities.js
+++ b/client/src/constants/CardPriorities.js
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+export const CARD_PRIORITY_MIN = 1;
+export const CARD_PRIORITY_MAX = 10;
+
+export const CardPriorityBands = {
+  LOW: 'low',
+  MEDIUM: 'medium',
+  HIGH: 'high',
+  VERY_HIGH: 'veryHigh',
+  URGENT: 'urgent',
+};
+
+const BANDS_BY_MAX_VALUE = [
+  {
+    maxValue: 2,
+    band: CardPriorityBands.LOW,
+    color: '#9e9e9e',
+  },
+  {
+    maxValue: 4,
+    band: CardPriorityBands.MEDIUM,
+    color: '#1976d2',
+  },
+  {
+    maxValue: 6,
+    band: CardPriorityBands.HIGH,
+    color: '#f57f17',
+  },
+  {
+    maxValue: 8,
+    band: CardPriorityBands.VERY_HIGH,
+    color: '#e65100',
+  },
+  {
+    maxValue: 10,
+    band: CardPriorityBands.URGENT,
+    color: '#cd2626',
+  },
+];
+
+export const getCardPriorityBand = (value) =>
+  (BANDS_BY_MAX_VALUE.find(({ maxValue }) => value <= maxValue) || BANDS_BY_MAX_VALUE.at(-1)).band;
+
+export const getCardPriorityColor = (value) =>
+  (BANDS_BY_MAX_VALUE.find(({ maxValue }) => value <= maxValue) || BANDS_BY_MAX_VALUE.at(-1)).color;

--- a/client/src/locales/en-US/core.js
+++ b/client/src/locales/en-US/core.js
@@ -272,6 +272,7 @@ export default {
         'PLANKA uses <1><0>Apprise</0></1> to send notifications to over 100 popular services.',
       port: 'Port',
       preferences: 'Preferences',
+      priority: 'Priority',
       pressPasteShortcutToAddAttachmentFromClipboard:
         'Tip: press Ctrl-V (Cmd-V on Mac) to add an attachment from the clipboard.',
       private: 'Private',

--- a/client/src/models/Card.js
+++ b/client/src/models/Card.js
@@ -18,6 +18,9 @@ export default class extends BaseModel {
     type: attr(),
     position: attr(),
     name: attr(),
+    priority: attr({
+      getDefault: () => 0,
+    }),
     description: attr(),
     dueDate: attr(),
     isDueCompleted: attr(),
@@ -650,6 +653,7 @@ export default class extends BaseModel {
       type: this.type,
       position: this.position,
       name: this.name,
+      priority: this.priority,
       description: this.description,
       dueDate: this.dueDate,
       isDueCompleted: this.isDueCompleted,

--- a/server/api/controllers/cards/update.js
+++ b/server/api/controllers/cards/update.js
@@ -56,6 +56,12 @@
  *                 maxLength: 1024
  *                 description: Name/title of the card
  *                 example: Implement user authentication
+ *               priority:
+ *                 type: number
+ *                 minimum: 0
+ *                 maximum: 10
+ *                 description: Priority of the card, from 0 (no priority) to 10 (most urgent)
+ *                 example: 7
  *               description:
  *                 type: string
  *                 maxLength: 1048576
@@ -173,6 +179,11 @@ module.exports = {
       isNotEmptyString: true,
       maxLength: 1024,
     },
+    priority: {
+      type: 'number',
+      min: 0,
+      max: 10,
+    },
     description: {
       type: 'string',
       isNotEmptyString: true,
@@ -252,6 +263,7 @@ module.exports = {
         'type',
         'position',
         'name',
+        'priority',
         'description',
         'dueDate',
         'isDueCompleted',
@@ -312,6 +324,7 @@ module.exports = {
       'type',
       'position',
       'name',
+      'priority',
       'description',
       'dueDate',
       'isDueCompleted',

--- a/server/api/models/Card.js
+++ b/server/api/models/Card.js
@@ -26,6 +26,7 @@
  *         - type
  *         - position
  *         - name
+ *         - priority
  *         - description
  *         - dueDate
  *         - isDueCompleted
@@ -77,6 +78,13 @@
  *           type: string
  *           description: Name/title of the card
  *           example: Implement user authentication
+ *         priority:
+ *           type: number
+ *           default: 0
+ *           minimum: 0
+ *           maximum: 10
+ *           description: Priority of the card, from 0 (no priority) to 10 (most urgent)
+ *           example: 7
  *         description:
  *           type: string
  *           nullable: true
@@ -165,6 +173,10 @@ module.exports = {
     name: {
       type: 'string',
       required: true,
+    },
+    priority: {
+      type: 'number',
+      defaultsTo: 0,
     },
     description: {
       type: 'string',

--- a/server/db/migrations/20260719120000_add_priority_to_cards.js
+++ b/server/db/migrations/20260719120000_add_priority_to_cards.js
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+exports.up = (knex) =>
+  knex.schema.alterTable('card', (table) => {
+    table.smallint('priority').notNullable().defaultTo(0);
+  });
+
+exports.down = (knex) =>
+  knex.schema.alterTable('card', (table) => {
+    table.dropColumn('priority');
+  });


### PR DESCRIPTION
## Summary
- Adds a priority field to **project cards**, on a 1-10 scale grouped into five color bands (1-2 low/grey, 3-4 medium/blue #1976d2, 5-6 high/yellow #f57f17, 7-8 very high/orange #e65100, 9-10 urgent/red #cd2626).
- Set via a slider in the card detail modal (sidebar Add to card action + detail row, mirroring the existing Due Date UX); shown as a colored numeric badge both there and on the Kanban card front.
- Syncs over the existing WebSocket cardUpdate broadcast automatically, no extra realtime wiring needed.
- Scoped to project-type cards only, matching the existing precedent set by dueDate/stopwatch.

## Test plan
- [ ] `cd server && npm run db:migrate` applies the new migration (card.priority, smallint NOT NULL DEFAULT 0)
- [ ] `cd server && npm run lint` and `cd client && npm run lint` pass
- [ ] Open a project card, use Add to card -> Priority, drag the slider, Save, confirm the badge appears on the card detail and on the Kanban card front with the right number/color
- [ ] Confirm Remove clears the priority back to no badge
- [ ] Open the same board in two browser tabs, change priority in one, confirm it updates live in the other via WebSocket

Closes #936