### PR TITLE
feat(webhooks): add cardDueDateExpired event

### DIFF
--- a/client/src/constants/WebhookEvents.js
+++ b/client/src/constants/WebhookEvents.js
@@ -28,6 +28,7 @@ export default [
   'cardCreate',
   'cardUpdate',
   'cardDelete',
+  'cardDueDateExpired',
 
   'cardLabelCreate',
   'cardLabelDelete',

--- a/server/api/helpers/cards/notify-due-date-expiration.js
+++ b/server/api/helpers/cards/notify-due-date-expiration.js
@@ -1,0 +1,68 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+module.exports = {
+  inputs: {
+    id: {
+      type: 'string',
+      required: true,
+    },
+    webhooks: {
+      type: 'ref',
+    },
+  },
+
+  async fn(inputs) {
+    let pathToProject;
+    try {
+      pathToProject = await sails.helpers.cards.getPathToProjectById(inputs.id);
+    } catch (error) {
+      return; // Card no longer exists
+    }
+
+    const { card, list, board, project } = pathToProject;
+
+    if (
+      !card.dueDate ||
+      card.isDueCompleted ||
+      card.dueDateExpirationNotifiedAt ||
+      new Date(card.dueDate).getTime() > Date.now()
+    ) {
+      return;
+    }
+
+    if (sails.helpers.lists.isArchiveOrTrash(list)) {
+      return;
+    }
+
+    const { webhooks = await Webhook.qm.getAll() } = inputs;
+
+    const { card: updatedCard } = await Card.qm.updateOne(card.id, {
+      dueDateExpirationNotifiedAt: new Date().toISOString(),
+    });
+
+    if (!updatedCard) {
+      return;
+    }
+
+    sails.sockets.broadcast(`board:${board.id}`, 'cardUpdate', {
+      item: updatedCard,
+    });
+
+    sails.helpers.utils.sendWebhooks.with({
+      webhooks,
+      event: Webhook.Events.CARD_DUE_DATE_EXPIRED,
+      buildData: () => ({
+        item: updatedCard,
+        included: {
+          projects: [project],
+          boards: [board],
+          lists: [list],
+        },
+      }),
+      user: null,
+    });
+  },
+};

--- a/server/api/helpers/cards/update-one.js
+++ b/server/api/helpers/cards/update-one.js
@@ -105,6 +105,17 @@ module.exports = {
       }
     }
 
+    if (!_.isUndefined(values.dueDate)) {
+      const hasDueDateChanged =
+        values.dueDate && inputs.record.dueDate
+          ? new Date(values.dueDate).getTime() !== new Date(inputs.record.dueDate).getTime()
+          : values.dueDate !== inputs.record.dueDate;
+
+      if (hasDueDateChanged) {
+        values.dueDateExpirationNotifiedAt = null;
+      }
+    }
+
     const dueDate = _.isUndefined(values.dueDate) ? inputs.record.dueDate : values.dueDate;
 
     if (dueDate) {

--- a/server/api/helpers/utils/send-webhooks.js
+++ b/server/api/helpers/utils/send-webhooks.js
@@ -129,15 +129,10 @@ module.exports = {
 
     const data = inputs.buildData();
     const prevData = inputs.buildPrevData && inputs.buildPrevData();
+    const user = inputs.user && sails.helpers.users.presentOne(inputs.user);
 
     webhooks.forEach((webhook) => {
-      sendWebhook(
-        webhook,
-        inputs.event,
-        data,
-        prevData,
-        sails.helpers.users.presentOne(inputs.user),
-      );
+      sendWebhook(webhook, inputs.event, data, prevData, user);
     });
   },
 };

--- a/server/api/hooks/due-date-watcher/index.js
+++ b/server/api/hooks/due-date-watcher/index.js
@@ -1,0 +1,46 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+/**
+ * due-date-watcher hook
+ *
+ * @description :: A hook definition. Extends Sails by adding shadow routes, implicit actions,
+ *                 and/or initialization logic.
+ * @docs        :: https://sailsjs.com/docs/concepts/extending-sails/hooks
+ */
+
+module.exports = function defineDueDateWatcherHook(sails) {
+  const checkExpiredDueDates = async () => {
+    const cards = await Card.qm.getWithExpiredDueDate();
+
+    if (cards.length === 0) {
+      return;
+    }
+
+    const webhooks = await Webhook.qm.getAll();
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const card of cards) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await sails.helpers.cards.notifyDueDateExpiration(card.id, webhooks);
+      } catch (error) {
+        sails.log.error(`Error notifying due date expiration for card ${card.id}: ${error}`);
+      }
+    }
+  };
+
+  return {
+    /**
+     * Runs when this Sails app loads/lifts.
+     */
+
+    async initialize() {
+      sails.log.info('Initializing custom hook (`due-date-watcher`)');
+
+      setInterval(checkExpiredDueDates, sails.config.custom.dueDateExpirationCheckInterval * 1000);
+    },
+  };
+};

--- a/server/api/hooks/query-methods/models/Card.js
+++ b/server/api/hooks/query-methods/models/Card.js
@@ -175,6 +175,17 @@ const getOneById = (id, { listId } = {}) => {
   return Card.findOne(criteria);
 };
 
+const getWithExpiredDueDate = () =>
+  defaultFind({
+    dueDate: {
+      '<': new Date().toISOString(),
+    },
+    isDueCompleted: {
+      '!=': true,
+    },
+    dueDateExpirationNotifiedAt: null,
+  });
+
 const update = async (criteria, values) => {
   if (!_.isUndefined(values.isClosed)) {
     return sails.getDatastore().transaction(async (db) => {
@@ -240,6 +251,7 @@ module.exports = {
   getByEndlessListId,
   getByListIds,
   getOneById,
+  getWithExpiredDueDate,
   update,
   updateOne,
   deleteOne,

--- a/server/api/models/Card.js
+++ b/server/api/models/Card.js
@@ -180,6 +180,10 @@ module.exports = {
       allowNull: true,
       columnName: 'is_due_completed',
     },
+    dueDateExpirationNotifiedAt: {
+      type: 'ref',
+      columnName: 'due_date_expiration_notified_at',
+    },
     stopwatch: {
       type: 'json',
     },

--- a/server/api/models/Webhook.js
+++ b/server/api/models/Webhook.js
@@ -96,6 +96,7 @@ const Events = {
   CARD_CREATE: 'cardCreate',
   CARD_UPDATE: 'cardUpdate',
   CARD_DELETE: 'cardDelete',
+  CARD_DUE_DATE_EXPIRED: 'cardDueDateExpired',
 
   CARD_LABEL_CREATE: 'cardLabelCreate',
   CARD_LABEL_DELETE: 'cardLabelDelete',

--- a/server/config/custom.js
+++ b/server/config/custom.js
@@ -50,6 +50,9 @@ module.exports.custom = {
   storageLimit: envToBytes(process.env.STORAGE_LIMIT),
   activeUsersLimit: envToNumber(process.env.ACTIVE_USERS_LIMIT),
 
+  // In seconds
+  dueDateExpirationCheckInterval: envToNumber(process.env.DUE_DATE_EXPIRATION_CHECK_INTERVAL) || 60,
+
   // Location to receive uploaded files in. Default (non-string value) is a Sails-specific location.
   uploadsTempPath: null,
   uploadsBasePath: path.join(sails.config.appPath, 'data'),

--- a/server/db/migrations/20260719180000_add_card_due_date_expiration_notified_at.js
+++ b/server/db/migrations/20260719180000_add_card_due_date_expiration_notified_at.js
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) 2024 PLANKA Software GmbH
+ * Licensed under the Fair Use License: https://github.com/plankanban/planka/blob/master/LICENSE.md
+ */
+
+module.exports.up = (knex) =>
+  knex.schema.alterTable('card', (table) => {
+    table.timestamp('due_date_expiration_notified_at', true);
+  });
+
+module.exports.down = (knex) =>
+  knex.schema.alterTable('card', (table) => {
+    table.dropColumn('due_date_expiration_notified_at');
+  });


### PR DESCRIPTION
Adds a periodic due-date-watcher hook that detects cards whose dueDate has passed and are not marked complete, then emits both a cardDueDateExpired webhook (with a null user, since it is system-triggered) and a real-time cardUpdate socket broadcast. Archive/Trash cards are excluded, and the notified state resets whenever a card's dueDate changes so it can expire again.