### PR TITLE
feat: Add backup cronjob for helm chart

### DIFF
--- a/charts/planka/README.md
+++ b/charts/planka/README.md
@@ -271,4 +271,33 @@ image:
 - **Reproducibility**: Makes deployments fully reproducible across environments
 - **Audit Trail**: Provides clear image identity in deployment manifests
 
+### Optional Kubernetes Backup CronJob
+
+The chart can create an optional backup CronJob. It follows the same
+`postgres.sql` plus `data/` layout as Planka's official Docker backup script.
+It is disabled by default.
+
+The backup image is published at
+`ghcr.io/sinae99/planka-k8s-backup`. Publish a new version by following the
+[GHCR guide](https://github.com/sinae99/planka-k8s-backup/blob/main/guide/publish-to-ghcr.md),
+then configure the image below:
+
+```yaml
+backup:
+  enabled: true
+  image:
+    repository: ghcr.io/sinae99/planka-k8s-backup
+    tag: "1.0.0"
+  existingSecret: planka-backup-s3
+```
+
+Create `planka-backup-s3` with the S3 credentials before enabling the chart.
+The public GHCR image does not need an image pull Secret. The chart creates the
+CronJob and namespace-scoped RBAC.
+
+See [`docs/backup-cronjob/`](docs/backup-cronjob/) for the short setup guide.
+
+### Complete Example
+
+See [`docs/backup-cronjob/values.example.yaml`](docs/backup-cronjob/values.example.yaml) for a backup configuration example.
 ````

--- a/charts/planka/docs/backup-cronjob/README.md
+++ b/charts/planka/docs/backup-cronjob/README.md
@@ -1,0 +1,74 @@
+# Planka backup CronJob
+
+This optional Helm feature uses the backup image published from:
+
+<https://github.com/sinae99/planka-k8s-backup>
+
+The image follows Planka's official Docker backup layout:
+
+```text
+<timestamp>-backup/
+├── postgres.sql
+└── data/
+```
+
+## 1. Publish the image
+
+Publish a version to GHCR using the
+[backup repository guide](https://github.com/sinae99/planka-k8s-backup/blob/main/guide/publish-to-ghcr.md).
+The default image is:
+
+```text
+ghcr.io/sinae99/planka-k8s-backup:1.0.0
+```
+
+Make the GHCR package public so Kubernetes can pull it without a registry
+Secret. Use the exact tag you published in Helm.
+
+## 2. Create the S3 Secret
+
+```bash
+kubectl -n planka create secret generic planka-backup-s3 \
+  --from-literal=S3_ENDPOINT=https://s3.example.com \
+  --from-literal=S3_ACCESS_KEY=replace-me \
+  --from-literal=S3_SECRET_KEY=replace-me \
+  --from-literal=S3_BUCKET_NAME=planka-backups \
+  --from-literal=S3_PREFIX=planka
+```
+
+## 3. Enable backup in Helm
+
+Add this to your Planka values file:
+
+```yaml
+backup:
+  enabled: true
+  image:
+    repository: ghcr.io/sinae99/planka-k8s-backup
+    tag: 1.0.0
+  existingSecret: planka-backup-s3
+```
+
+Then upgrade the release:
+
+```bash
+helm upgrade --install planka planka/planka \
+  --namespace planka \
+  --create-namespace \
+  -f values.yaml
+```
+
+The chart creates the CronJob, ServiceAccount, and namespace-scoped RBAC.
+The default schedule is weekly.
+
+## 4. Test it
+
+```bash
+kubectl -n planka create job planka-backup-manual \
+  --from=cronjob/planka-backup
+kubectl -n planka logs -f job/planka-backup-manual
+kubectl -n planka delete job planka-backup-manual
+```
+
+Confirm the archive appears in the configured bucket. Test a restore before
+using the backup in production.

--- a/charts/planka/docs/backup-cronjob/values.example.yaml
+++ b/charts/planka/docs/backup-cronjob/values.example.yaml
@@ -1,0 +1,22 @@
+# Example values for the optional Kubernetes backup CronJob.
+# Published backup image from github.com/sinae99/planka-k8s-backup.
+
+backup:
+  enabled: true
+  schedule: "0 3 * * 0"
+  image:
+    repository: ghcr.io/sinae99/planka-k8s-backup
+    tag: "1.0.0"
+    pullPolicy: IfNotPresent
+  existingSecret: planka-backup-s3
+  retentionCount: 4
+
+# The chart defaults below assume the Bitnami PostgreSQL dependency is enabled.
+# Override them when using an external database or non-standard resource names.
+# backup:
+#   postgresSecretName: planka-postgresql
+#   postgresPodName: planka-postgresql-0
+#   postgresDatabase: planka
+#   postgresUser: postgres
+#   plankaDeploymentName: planka
+#   plankaPodName: planka-xxxxxxxxx-yyyyy

--- a/charts/planka/templates/_helpers.tpl
+++ b/charts/planka/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the backup service account to use
+*/}}
+{{- define "planka.backupServiceAccountName" -}}
+{{- if .Values.backup.serviceAccount.create }}
+{{- default (printf "%s-backup" (include "planka.fullname" .)) .Values.backup.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- default "default" .Values.backup.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/planka/templates/backup-cronjob.yaml
+++ b/charts/planka/templates/backup-cronjob.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.backup.enabled }}
+{{- $backupImageTag := .Values.backup.image.tag }}
+{{- $postgresSecretName := default (printf "%s-postgresql" (include "planka.fullname" .)) .Values.backup.postgresSecretName }}
+{{- $postgresPodName := default (printf "%s-postgresql-0" (include "planka.fullname" .)) .Values.backup.postgresPodName }}
+{{- $postgresDatabase := default .Values.postgresql.auth.database .Values.backup.postgresDatabase }}
+{{- $plankaDeploymentName := default (include "planka.fullname" .) .Values.backup.plankaDeploymentName }}
+{{- if not .Values.backup.image.repository }}
+{{- fail "backup.image.repository is required when backup.enabled is true" }}
+{{- end }}
+{{- if not .Values.backup.existingSecret }}
+{{- fail "backup.existingSecret is required when backup.enabled is true" }}
+{{- end }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "planka.fullname" . }}-backup
+  labels:
+    {{- include "planka.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      ttlSecondsAfterFinished: {{ .Values.backup.ttlSecondsAfterFinished }}
+      template:
+        metadata:
+          labels:
+            {{- include "planka.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          serviceAccountName: {{ include "planka.backupServiceAccountName" . }}
+          restartPolicy: Never
+          securityContext:
+            {{- toYaml .Values.backup.podSecurityContext | nindent 12 }}
+          {{- with .Values.backup.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: backup
+              {{- if .Values.backup.image.digest }}
+              {{- if $backupImageTag }}
+              image: "{{ .Values.backup.image.repository }}:{{ $backupImageTag }}@sha256:{{ .Values.backup.image.digest }}"
+              {{- else }}
+              image: "{{ .Values.backup.image.repository }}@sha256:{{ .Values.backup.image.digest }}"
+              {{- end }}
+              {{- else }}
+              image: "{{ .Values.backup.image.repository }}:{{ $backupImageTag | default "latest" }}"
+              {{- end }}
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+              securityContext:
+                {{- toYaml .Values.backup.securityContext | nindent 16 }}
+              envFrom:
+                - secretRef:
+                    name: {{ .Values.backup.existingSecret }}
+              env:
+                - name: KUBE_NAMESPACE
+                  value: {{ .Release.Namespace | quote }}
+                - name: KUBE_POD_POSTGRES
+                  value: {{ $postgresPodName | quote }}
+                - name: KUBE_DEPLOYMENT_PLANKA
+                  value: {{ $plankaDeploymentName | quote }}
+                - name: POSTGRES_USER
+                  value: {{ .Values.backup.postgresUser | quote }}
+                - name: POSTGRES_DB
+                  value: {{ $postgresDatabase | quote }}
+                - name: POSTGRES_SECRET_NAME
+                  value: {{ $postgresSecretName | quote }}
+                - name: POSTGRES_SECRET_KEY
+                  value: {{ .Values.backup.postgresSecretKey | quote }}
+                - name: RETENTION_COUNT
+                  value: {{ .Values.backup.retentionCount | quote }}
+                {{- with .Values.backup.plankaPodName }}
+                - name: KUBE_POD_PLANKA
+                  value: {{ . | quote }}
+                {{- end }}
+                {{- with .Values.backup.extraEnv }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+          {{- with .Values.backup.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backup.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backup.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/planka/templates/backup-rbac.yaml
+++ b/charts/planka/templates/backup-rbac.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.backup.enabled .Values.backup.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "planka.fullname" . }}-backup
+  labels:
+    {{- include "planka.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    resourceNames:
+      - {{ default (printf "%s-postgresql" (include "planka.fullname" .)) .Values.backup.postgresSecretName | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "planka.fullname" . }}-backup
+  labels:
+    {{- include "planka.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "planka.fullname" . }}-backup
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "planka.backupServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/planka/templates/backup-serviceaccount.yaml
+++ b/charts/planka/templates/backup-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.backup.enabled .Values.backup.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "planka.backupServiceAccountName" . }}
+  labels:
+    {{- include "planka.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+  {{- with .Values.backup.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/planka/values.yaml
+++ b/charts/planka/values.yaml
@@ -246,4 +246,57 @@ extraContainers: []
 ##       - name: planka
 ##         mountPath: /var/log
 ##         subPath: app-logs
+
+## Optional in-cluster backup CronJob.
+## The image must contain kubectl, mc, and a backup script compatible with the
+## environment variables documented in charts/planka/docs/backup-cronjob.
+backup:
+  enabled: false
+  schedule: "0 3 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+
+  image:
+    repository: ""
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+
+  imagePullSecrets: []
+
+  ## Name of an existing Secret containing the backup image's object-storage
+  ## variables, for example S3_ENDPOINT, S3_ACCESS_KEY, and S3_SECRET_KEY.
+  existingSecret: ""
+
+  ## These values match the environment contract used by the reference
+  ## Kubernetes implementation. Empty values use the in-chart defaults.
+  postgresSecretName: ""
+  postgresSecretKey: postgres-password
+  postgresPodName: ""
+  postgresUser: postgres
+  postgresDatabase: ""
+  plankaDeploymentName: ""
+  plankaPodName: ""
+  retentionCount: 4
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+
+  rbac:
+    create: true
+
+  resources: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  ## Additional environment variables for the backup image.
+  extraEnv: []
 ##


### PR DESCRIPTION
## Planka Backup based on official docker script

This PR adds an optional backup CronJob to the Planka Helm chart.

This is based on the backup flow from Planka's official Docker solution.

Docker backup script exports the PostgreSQL database and copies the Planka
data directory.

## What I added

- Added an optional `backup-cronjob.yaml` template to the chart.
- Added an existing Secret option for S3 or other object-storage settings.
- Added a ServiceAccount for the backup job.
- Added namespace-scoped RBAC for reading the required pods and PostgreSQL
  Secret, and for running commands in the pods.
- Added instructions for creating the S3 Secret, installing the chart, and
  running a manual backup Job for testing.